### PR TITLE
Compute PCCs only for OCR and create data structure for querying PCCs

### DIFF
--- a/docile/dataset/__init__.py
+++ b/docile/dataset/__init__.py
@@ -1,5 +1,7 @@
+from docile.dataset.bbox import BBox
 from docile.dataset.dataset import Dataset
 from docile.dataset.document import Document
-from docile.dataset.field import PCC, BBox, Field
+from docile.dataset.field import Field
+from docile.dataset.pcc import PCC, PCCSet
 
-__all__ = ["BBox", "Dataset", "Document", "Field", "PCC"]
+__all__ = ["BBox", "Dataset", "Document", "Field", "PCC", "PCCSet"]

--- a/docile/dataset/bbox.py
+++ b/docile/dataset/bbox.py
@@ -1,0 +1,28 @@
+import dataclasses
+from typing import Tuple
+
+
+@dataclasses.dataclass(frozen=True)
+class BBox:
+    left: float
+    top: float
+    right: float
+    bottom: float
+
+    def to_absolute_coords(self, width: float, height: float) -> "BBox":
+        return BBox(
+            self.left * width,
+            self.top * height,
+            self.right * width,
+            self.bottom * height,
+        )
+
+    def to_tuple(self) -> Tuple[float, float, float, float]:
+        return self.left, self.top, self.right, self.bottom
+
+    def intersects(self, other: "BBox") -> bool:
+        if self.left > other.right or other.left > self.right:
+            return False
+        if self.top > other.bottom or other.top > self.bottom:
+            return False
+        return True

--- a/docile/dataset/field.py
+++ b/docile/dataset/field.py
@@ -1,40 +1,7 @@
 import dataclasses
-from typing import Any, List, Mapping, Optional, Tuple
+from typing import Any, Mapping, Optional
 
-
-@dataclasses.dataclass(frozen=True)
-class BBox:
-    left: float
-    top: float
-    right: float
-    bottom: float
-
-    def to_absolute_coords(self, width: float, height: float) -> "BBox":
-        return BBox(
-            self.left * width,
-            self.top * height,
-            self.right * width,
-            self.bottom * height,
-        )
-
-    def to_tuple(self) -> Tuple[float, float, float, float]:
-        return self.left, self.top, self.right, self.bottom
-
-    def intersects(self, other: "BBox") -> bool:
-        if self.left > other.right or other.left > self.right:
-            return False
-        if self.top > other.bottom or other.top > self.bottom:
-            return False
-        return True
-
-
-@dataclasses.dataclass(slots=True, frozen=True)
-class PCC:
-    """Wrapper for a position in the document."""
-
-    x: float
-    y: float
-    page: int
+from docile.dataset.bbox import BBox
 
 
 @dataclasses.dataclass(frozen=True)
@@ -45,14 +12,6 @@ class Field:
     text: Optional[str] = None
     fieldtype: Optional[str] = None
     line_item_id: Optional[int] = None
-    pccs: List[PCC] = dataclasses.field(init=False, compare=False)
-
-    def __post_init__(self) -> None:
-        if self.text:
-            pccs = self._calculate_pccs(self.bbox, self.text)
-        else:
-            pccs = []
-        object.__setattr__(self, "pccs", pccs)
 
     @classmethod
     def from_annotation(cls, annotation_dict: Mapping[str, Any]) -> "Field":
@@ -64,12 +23,3 @@ class Field:
     def from_ocr(cls, ocr_dict: Mapping[str, Any], page: int) -> "Field":
         lt, rb = ocr_dict["geometry"]
         return cls(text=ocr_dict["value"], bbox=BBox(lt[0], lt[1], rb[0], rb[1]), page=page)
-
-    def _calculate_pccs(self, bbox: BBox, text: str) -> List[PCC]:
-        """Calculate Pseudo Character Boxes (PCCs) given bbox and text."""
-        char_width = (bbox.right - bbox.left) / len(text)
-        y_middle = (bbox.top + bbox.bottom) / 2
-        return [
-            PCC(x=bbox.left + (i + 1 / 2) * char_width, y=y_middle, page=self.page)
-            for i in range(len(text))
-        ]

--- a/docile/dataset/pcc.py
+++ b/docile/dataset/pcc.py
@@ -1,0 +1,55 @@
+import dataclasses
+from bisect import bisect_left, bisect_right
+from collections import defaultdict
+from typing import List, Sequence, Set
+
+from docile.dataset.bbox import BBox
+
+
+@dataclasses.dataclass(slots=True, frozen=True)
+class PCC:
+    """Wrapper for a position in the document."""
+
+    x: float
+    y: float
+    page: int
+
+
+def calculate_pccs(bbox: BBox, text: str, page: int) -> List[PCC]:
+    if text == "":
+        raise ValueError("Cannot calculate PCCs from empty text")
+
+    char_width = (bbox.right - bbox.left) / len(text)
+    y_middle = (bbox.top + bbox.bottom) / 2
+    return [
+        PCC(x=bbox.left + (i + 1 / 2) * char_width, y=y_middle, page=page)
+        for i in range(len(text))
+    ]
+
+
+class PCCSet:
+    def __init__(self, pccs: Sequence[PCC]) -> None:
+        page_to_pccs = defaultdict(list)
+        for pcc in pccs:
+            page_to_pccs[pcc.page].append(pcc)
+
+        self._page_to_sorted_x_pccs = {
+            page: sorted(page_pccs, key=lambda p: p.x) for page, page_pccs in page_to_pccs.items()
+        }
+        self._page_to_sorted_y_pccs = {
+            page: sorted(page_pccs, key=lambda p: p.y) for page, page_pccs in page_to_pccs.items()
+        }
+
+    def get_covered_pccs(self, bbox: BBox, page: int) -> Set[PCC]:
+        sorted_x_pccs = self._page_to_sorted_x_pccs[page]
+        sorted_y_pccs = self._page_to_sorted_y_pccs[page]
+
+        i_l = bisect_left(sorted_x_pccs, bbox.left, key=lambda p: p.x)
+        i_r = bisect_right(sorted_x_pccs, bbox.right, key=lambda p: p.x)
+        x_subset = set(sorted_x_pccs[i_l:i_r])
+
+        i_t = bisect_left(sorted_y_pccs, bbox.top, key=lambda p: p.y)
+        i_b = bisect_right(sorted_y_pccs, bbox.bottom, key=lambda p: p.y)
+        y_subset = set(sorted_y_pccs[i_t:i_b])
+
+        return x_subset.intersection(y_subset)

--- a/docile/evaluation/line_item_matching.py
+++ b/docile/evaluation/line_item_matching.py
@@ -3,7 +3,7 @@ from typing import Dict, Iterable, List, Sequence, Tuple
 
 import networkx
 
-from docile.dataset import PCC, BBox, Field
+from docile.dataset import BBox, Field, PCCSet
 from docile.evaluation.pcc_field_matching import FieldMatching, MatchedPair, get_matches
 
 
@@ -35,7 +35,7 @@ def _get_covering_bbox(bboxes: Iterable[BBox]) -> BBox:
 def get_lir_matches(
     predictions: Sequence[Field],
     annotations: Sequence[Field],
-    pccs: Sequence[PCC],
+    pcc_set: PCCSet,
     iou_threshold: float = 1,
 ) -> Tuple[FieldMatching, Dict[int, int]]:
     """
@@ -89,7 +89,10 @@ def get_lir_matches(
                 field_matching = FieldMatching(matches=[], extra=preds, misses=golds)
             else:
                 field_matching = get_matches(
-                    predictions=preds, annotations=golds, pccs=pccs, iou_threshold=iou_threshold
+                    predictions=preds,
+                    annotations=golds,
+                    pcc_set=pcc_set,
+                    iou_threshold=iou_threshold,
                 )
 
             G.add_edge(

--- a/tests/dataset/test_bbox.py
+++ b/tests/dataset/test_bbox.py
@@ -1,4 +1,4 @@
-from docile.dataset.field import BBox
+from docile.dataset.bbox import BBox
 
 
 def test_bbox_to_absolute_coords() -> None:

--- a/tests/dataset/test_pcc.py
+++ b/tests/dataset/test_pcc.py
@@ -1,0 +1,30 @@
+import pytest
+
+from docile.dataset.bbox import BBox
+from docile.dataset.pcc import PCC, PCCSet, calculate_pccs
+
+
+def test_calculate_pccs() -> None:
+    bbox = BBox(0.2, 0.1, 0.8, 0.3)
+    with pytest.raises(ValueError):
+        assert calculate_pccs(bbox, "", 0)
+
+    y = pytest.approx(0.2)
+    assert calculate_pccs(bbox, "x", 0) == [PCC(pytest.approx(0.5), y, 0)]  # type: ignore
+    assert calculate_pccs(bbox, "xx", 1) == [
+        PCC(pytest.approx(0.35), y, 1),  # type: ignore
+        PCC(pytest.approx(0.65), y, 1),  # type: ignore
+    ]
+    assert calculate_pccs(bbox, "xxx", 2) == [
+        PCC(pytest.approx(0.3), y, 2),  # type: ignore
+        PCC(pytest.approx(0.5), y, 2),  # type: ignore
+        PCC(pytest.approx(0.7), y, 2),  # type: ignore
+    ]
+
+
+def test_get_covered_pccs() -> None:
+    pccs = [PCC(0, 0.5, 0), PCC(0.5, 0.5, 0), PCC(1, 1, 0), PCC(0.5, 0.5, 1), PCC(0.4, 0.6, 1)]
+    pcc_set = PCCSet(pccs)
+    bbox = BBox(0.25, 0.25, 0.75, 0.75)
+    assert pcc_set.get_covered_pccs(bbox, 0) == {pccs[1]}
+    assert pcc_set.get_covered_pccs(bbox, 1) == {pccs[3], pccs[4]}

--- a/tests/evaluation/test_line_item_matching.py
+++ b/tests/evaluation/test_line_item_matching.py
@@ -1,6 +1,6 @@
 import pytest
 
-from docile.dataset import PCC, BBox, Field
+from docile.dataset import PCC, BBox, Field, PCCSet
 from docile.evaluation.line_item_matching import (
     _get_covering_bbox,
     _get_line_item_id,
@@ -40,15 +40,17 @@ def test_get_covering_bbox() -> None:
 
 
 def test_get_lir_matches() -> None:
-    pccs = [
-        PCC(0, 0, 0),
-        PCC(0.1, 0.1, 0),
-        PCC(0.2, 0.1, 0),
-        PCC(0.5, 0.4, 0),
-        PCC(0.5, 0.6, 0),
-        PCC(1, 1, 0),
-        PCC(0.1, 0.1, 1),
-    ]
+    pcc_set = PCCSet(
+        [
+            PCC(0, 0, 0),
+            PCC(0.1, 0.1, 0),
+            PCC(0.2, 0.1, 0),
+            PCC(0.5, 0.4, 0),
+            PCC(0.5, 0.6, 0),
+            PCC(1, 1, 0),
+            PCC(0.1, 0.1, 1),
+        ]
+    )
 
     annotations = [
         Field(fieldtype="a", text="ab", line_item_id=0, bbox=BBox(0.4, 0.4, 0.7, 0.7), page=0),
@@ -74,7 +76,9 @@ def test_get_lir_matches() -> None:
     # While greedy matching might assign pred line item (LI) 1 to gold LI 2, maximum matching
     # will assign it to gold LI 1 (so that pred LI 2 can be assigned to gold LI 2).
 
-    field_matching, li_matching = get_lir_matches(predictions, annotations, pccs, iou_threshold=1)
+    field_matching, li_matching = get_lir_matches(
+        predictions=predictions, annotations=annotations, pcc_set=pcc_set, iou_threshold=1
+    )
     assert li_matching == {4: 0, 1: 1, 2: 2}
     assert set(field_matching.matches) == {
         MatchedPair(pred=predictions[0], gold=annotations[0]),


### PR DESCRIPTION
Speedup (evaluation of dataset with 1.8k documents decreased from 23 to 15 seconds) & improved structure achieved with a few changes:
* Don't compute PCCs for all fields (including predictions and annotations) but only for OCR words
* Define data structure `PCCSet` to hold and query PCCs for a document. This improves the API (passing this instead of low level `sorted_x_pccs, sorted_y_pccs` to functions) and also means precomputed artifacts are computed only once for each document.
  * If we want to later speedup the evaluation even more we can do it simply by changing PCCSet to use KD-trees.