### PR TITLE
hotfix: turn off memory cache

### DIFF
--- a/docile/dataset/cached_object.py
+++ b/docile/dataset/cached_object.py
@@ -48,4 +48,9 @@ class CachedObject(Generic[CT]):
             return content
 
         # Nothing had been found, we need to predict
-        return self.predict_and_overwrite()
+        try:
+            return self.predict_and_overwrite()
+        except NotImplementedError:
+            raise ValueError(
+                f"Object {self.path} not found in memory, on disk and cannot be created"
+            )

--- a/docile/dataset/document_annotation.py
+++ b/docile/dataset/document_annotation.py
@@ -8,7 +8,7 @@ from docile.dataset.field import Field
 
 class DocumentAnnotation(CachedObject[Dict]):
     def __init__(self, path: Path) -> None:
-        super().__init__(path=path, mem_cache=True, disk_cache=True)
+        super().__init__(path=path, mem_cache=False, disk_cache=True)
 
     def from_disk(self) -> Dict[str, Any]:
         return json.loads(self.path.read_text())

--- a/docile/dataset/document_images.py
+++ b/docile/dataset/document_images.py
@@ -28,7 +28,7 @@ class DocumentImages(CachedObject[List[Image.Image]]):
             Check https://pdf2image.readthedocs.io/en/latest/reference.html for documentation of
             this parameter.
         """
-        super().__init__(path=path, mem_cache=True, disk_cache=True)
+        super().__init__(path=path, mem_cache=False, disk_cache=True)
         self.pdf_path = pdf_path
         self.page_count = page_count
         self.size = size

--- a/docile/dataset/document_ocr.py
+++ b/docile/dataset/document_ocr.py
@@ -14,7 +14,7 @@ class DocumentOCR(CachedObject[Dict]):
     _model = None
 
     def __init__(self, path: Path, pdf_path: Path) -> None:
-        super().__init__(path=path, mem_cache=True, disk_cache=True)
+        super().__init__(path=path, mem_cache=False, disk_cache=True)
         self.pdf_path = pdf_path
 
     @classmethod


### PR DESCRIPTION
To make it work with the large pre-training dataset. Some (in-memory) caching still might be useful so we should solve this properly - e.g., by propagating the option to when the dataset is loaded.