### PR TITLE
Install docile as package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,4 +14,7 @@ RUN pip3 install poetry
 WORKDIR /app
 COPY poetry.lock pyproject.toml /app/
 
+COPY docile /app/docile
+COPY README.md /app/README.md
+
 RUN poetry install --no-interaction --with test --with doctr

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,9 +11,7 @@ services:
       - "${JUPYTER_PORT}:${JUPYTER_PORT}"
     command: poetry run jupyter lab --ip=0.0.0.0 --port=${JUPYTER_PORT} --allow-root
     volumes:
-      - "./docile:/app/docile:cached"
-      - "./data:/data:cached"
-      - "./logs:/logs:cached"
+      - "./:/app/:cached"
     deploy:
       resources:
         # consider reducing these limits

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,11 @@ authors = [
     "Milan Sulc <milan.sulc@rossum.ai>"
 ]
 readme = "README.md"
+homepage = "https://docile.rossum.ai/"
+repository = "https://github.com/rossumai/docile"
+packages = [
+    { include = "docile" },
+]
 
 [tool.poetry.dependencies]
 python = "~3.10"


### PR DESCRIPTION
Fix installation to make `docile` a proper package (importable from everywhere in the docker / in the virtual environment)