### PR TITLE
Store evaluation result

### DIFF
--- a/docile/cli/evaluate.py
+++ b/docile/cli/evaluate.py
@@ -1,9 +1,10 @@
 from pathlib import Path
+from typing import Optional
 
 import click
 
 from docile.dataset import CachingConfig, Dataset, load_predictions
-from docile.evaluation import evaluate_dataset
+from docile.evaluation import EvaluationResult, evaluate_dataset
 
 
 @click.command("Evaluate predictions on DocILE dataset")
@@ -38,6 +39,12 @@ from docile.evaluation import evaluate_dataset
     help="path to the json file with predictions",
 )
 @click.option(
+    "--store-evaluation-result",
+    type=click.Path(exists=False, file_okay=True, dir_okay=False, path_type=Path),
+    default=None,
+    help="path to a json file where to store the evaluation result",
+)
+@click.option(
     "--iou-threshold",
     type=float,
     default=1.0,
@@ -58,6 +65,7 @@ def evaluate(
     dataset_path: Path,
     split: str,
     predictions: Path,
+    store_evaluation_result: Optional[Path],
     iou_threshold: float,
     evaluate_also_text: bool,
     primary_metric_only: bool,
@@ -65,14 +73,14 @@ def evaluate(
     dataset = Dataset(split, dataset_path, cache_images=CachingConfig.OFF)
     docid_to_predictions = load_predictions(predictions)
     if task == "KILE":
-        evalution_result = evaluate_dataset(
+        evaluation_result = evaluate_dataset(
             dataset,
             docid_to_kile_predictions=docid_to_predictions,
             docid_to_lir_predictions={},
             iou_threshold=iou_threshold,
         )
     elif task == "LIR":
-        evalution_result = evaluate_dataset(
+        evaluation_result = evaluate_dataset(
             dataset,
             docid_to_kile_predictions={},
             docid_to_lir_predictions=docid_to_predictions,
@@ -80,12 +88,37 @@ def evaluate(
         )
     else:
         raise ValueError(f"Unknown task {task}")
+
+    if store_evaluation_result is not None:
+        evaluation_result.to_file(store_evaluation_result)
+
     if primary_metric_only:
-        metric_value = evalution_result.get_primary_metric(task.lower())
-        print(metric_value)  # noqa
+        metric_value = evaluation_result.get_primary_metric(task.lower())
+        print(metric_value)  # noqa T201
     else:
-        report = evalution_result.print_report(include_same_text=evaluate_also_text)
-        print(report)  # noqa
+        report = evaluation_result.print_report(include_same_text=evaluate_also_text)
+        print(report)  # noqa T201
+
+
+@click.command("Print evaluation previously done on DocILE dataset")
+@click.option(
+    "--evaluation-result-path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=False, path_type=Path),
+    required=True,
+    help="path to the json file with evaluation result",
+)
+@click.option(
+    "--evaluate-also-text",
+    is_flag=True,
+    help="if used, also show metrics that require exact text match for predictions",
+)
+def print_evaluation_report(
+    evaluation_result_path: Path,
+    evaluate_also_text: bool,
+) -> None:
+    evaluation_result = EvaluationResult.from_file(evaluation_result_path)
+    report = evaluation_result.print_report(include_same_text=evaluate_also_text)
+    print(report)  # noqa T201
 
 
 if __name__ == "__main__":

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -40,6 +40,7 @@ torchvision = "^0.13.0"
 
 [tool.poetry.scripts]
 evaluate = "docile.cli.evaluate:evaluate"
+print-evaluation-report = "docile.cli.evaluate:print_evaluation_report"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
The evaluation script can now store the evaluation result (matchings) in a file. This can be later loaded, e.g., for visualization purposes.