### PR TITLE
Simplify page image interface

### DIFF
--- a/docile/dataset/document_annotation.py
+++ b/docile/dataset/document_annotation.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from docile.dataset.cached_object import CachedObject, CachingConfig
 from docile.dataset.field import Field
@@ -34,6 +34,10 @@ class DocumentAnnotation(CachedObject[Dict]):
         Cluster represents a group of documents with the same layout.
         """
         return self.content["metadata"]["cluster_id"]
+
+    def page_size_at_200dpi(self, page: int) -> Tuple[int, int]:
+        """Get (width, height) tuple of the pdf page when rendered at 200 DPI."""
+        return self.content["metadata"]["page_sizes_at_200dpi"][page]
 
     def get_table_grid(self, page: int) -> Optional[TableGrid]:
         """

--- a/docile/dataset/document_images.py
+++ b/docile/dataset/document_images.py
@@ -6,7 +6,6 @@ from PIL import Image
 
 from docile.dataset.cached_object import CachedObject, CachingConfig
 from docile.dataset.paths import DataPaths, PathMaybeInZip
-from docile.dataset.types import OptionalImageSize
 
 logger = logging.getLogger(__name__)
 
@@ -17,7 +16,7 @@ class DocumentImages(CachedObject[List[Image.Image]]):
         path: PathMaybeInZip,
         pdf_path: PathMaybeInZip,
         page_count: int,
-        size: OptionalImageSize = (None, None),
+        dpi: int,
         cache: CachingConfig = CachingConfig.OFF,
     ):
         """
@@ -31,16 +30,15 @@ class DocumentImages(CachedObject[List[Image.Image]]):
             Path to the input pdf document.
         page_count
             Number of pages of the document.
-        size
-            Check https://pdf2image.readthedocs.io/en/latest/reference.html for documentation of
-            this parameter.
+        dpi
+            Quality at which the image is generated from the pdf.
         cache
             Whether to cache images generated from pdfs to disk and/or to memory.
         """
         super().__init__(path=path, cache=cache)
         self.pdf_path = pdf_path
         self.page_count = page_count
-        self.size = size
+        self.dpi = dpi
 
     def from_disk(self) -> List[Image.Image]:
         images = []
@@ -65,7 +63,7 @@ class DocumentImages(CachedObject[List[Image.Image]]):
             content[page_i].save(str(page_path.full_path))
 
     def predict(self) -> List[Image.Image]:
-        images = convert_from_bytes(self.pdf_path.read_bytes(), size=self.size)
+        images = convert_from_bytes(self.pdf_path.read_bytes(), dpi=self.dpi)
         if len(images) != self.page_count:
             raise RuntimeError(
                 f"Generated unexpected number of images: {len(images)} (expected: {self.page_count}"

--- a/docile/dataset/paths.py
+++ b/docile/dataset/paths.py
@@ -2,8 +2,6 @@ from pathlib import Path, PurePosixPath
 from typing import Optional, Union
 from zipfile import ZipFile
 
-from docile.dataset.types import OptionalImageSize
-
 
 class PathMaybeInZip:
     """Path that can point to the file system or to a path inside of a ZIP file."""
@@ -106,23 +104,11 @@ class DataPaths:
     def annotation_path(self, docid: str) -> PathMaybeInZip:
         return self.dataset_path / "annotations" / f"{docid}.json"
 
-    def cache_images_path(self, docid: str, size: OptionalImageSize) -> PathMaybeInZip:
+    def cache_images_path(self, docid: str, dpi: int) -> PathMaybeInZip:
         """Path to directory with cached images for the individual pages."""
-        directory_name = docid
-        size_tag = self._size_tag(size)
-        if size_tag != "":
-            directory_name += f"__{self._size_tag(size)}"
+        directory_name = f"{docid}__{dpi}dpi"
         return self.dataset_path / "cached_images" / directory_name
 
     @staticmethod
     def cache_page_image_path(cache_images_path: PathMaybeInZip, page_i: int) -> PathMaybeInZip:
         return cache_images_path / f"{page_i}.png"
-
-    @staticmethod
-    def _size_tag(size: OptionalImageSize) -> str:
-        """Convert size param to string. This string is used as part of the cache path for images."""
-        if size == (None, None):
-            return ""
-        if isinstance(size, int):
-            return str(size)
-        return f"{size[0]}x{size[1]}"

--- a/docile/dataset/types.py
+++ b/docile/dataset/types.py
@@ -1,3 +1,0 @@
-from typing import Optional, Tuple, Union
-
-OptionalImageSize = Union[int, Tuple[Optional[int], Optional[int]]]


### PR DESCRIPTION
Passing `dpi: int` is a simpler interface than passing the `image_size: Tuple[Optional[int], Optional[int]]`. In most cases it's enough and participants can always post-process the image if they need.

If efficiency is the question (it's not necessary to generate a huge image if it will be scaled down afterwards), the metadata contains the image size at 200 DPI so they can use it to decide a better DPI value to use for the image generation.