### PR TITLE
Getters for all available document annotations.

### DIFF
--- a/docile/dataset/document_annotation.py
+++ b/docile/dataset/document_annotation.py
@@ -1,5 +1,5 @@
 import json
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 from docile.dataset.cached_object import CachedObject, CachingConfig
 from docile.dataset.field import Field
@@ -8,6 +8,23 @@ from docile.dataset.table_grid import TableGrid
 
 
 class DocumentAnnotation(CachedObject[Dict]):
+    """
+    All annotations available for the document.
+
+    Unlabeled documents still have some annotations available, namely: page_count, cluster_id,
+    page_image_size_at_200dpi, source, original_filename. Notice that pre-computed OCR, which is
+    also available for unlabeled documents, is provided separately through `document.ocr`
+    (DocumentOCR class).
+
+    This is also true for the test set with the exception of cluster_id which is not shared.
+
+    Otherwise, all annotations are available for both annotated and synthetic documents, with the
+    exception of `template_document_id` which is only defined for the synthetic documents.
+
+    For synthetic documents, the values for document_type, source and original_filename are taken
+    from the template document.
+    """
+
     def __init__(self, path: PathMaybeInZip, cache: CachingConfig = CachingConfig.DISK) -> None:
         super().__init__(path=path, cache=cache)
 
@@ -20,17 +37,34 @@ class DocumentAnnotation(CachedObject[Dict]):
 
     @property
     def fields(self) -> List[Field]:
+        """All KILE fields on the document."""
         return [Field.from_dict(a) for a in self.content["field_extractions"]]
 
     def page_fields(self, page: int) -> List[Field]:
+        """KILE fields on the given page of the document."""
         return [f for f in self.fields if f.page == page]
 
     @property
     def li_fields(self) -> List[Field]:
+        """All LI fields on the document."""
         return [Field.from_dict(a) for a in self.content["line_item_extractions"]]
 
     def page_li_fields(self, page: int) -> List[Field]:
+        """LI fields on the given page of the document."""
         return [f for f in self.li_fields if f.page == page]
+
+    @property
+    def li_headers(self) -> List[Field]:
+        """
+        Fields corresponding to column headers in tables.
+
+        Predicting these fields is not part of the LIR task.
+        """
+        return [Field.from_dict(a) for a in self.content["line_item_headers"]]
+
+    def page_li_headers(self, page: int) -> List[Field]:
+        """Fields corresponding to column headers in tables on the given page."""
+        return [f for f in self.li_headers if f.page == page]
 
     @property
     def cluster_id(self) -> int:
@@ -40,6 +74,28 @@ class DocumentAnnotation(CachedObject[Dict]):
         Cluster represents a group of documents with the same layout.
         """
         return self.content["metadata"]["cluster_id"]
+
+    def page_image_size_at_200dpi(self, page: int) -> Tuple[int, int]:
+        """
+        Page image size at 200 DPI.
+
+        This is exactly equal to the generated image size when using `document.page_image(page)`
+        with the default parameters.
+        """
+        return self.content["metadata"]["page_sizes_at_200dpi"][page]
+
+    @property
+    def document_type(self) -> str:
+        return self.content["metadata"]["document_type"]
+
+    @property
+    def currency(self) -> str:
+        """Document currency or 'other' if no currency is specified on the document."""
+        return self.content["metadata"]["currency"]
+
+    @property
+    def language(self) -> str:
+        return self.content["metadata"]["language"]
 
     def get_table_grid(self, page: int) -> Optional[TableGrid]:
         """
@@ -62,3 +118,27 @@ class DocumentAnnotation(CachedObject[Dict]):
         if table_grid_dict is None:
             return None
         return TableGrid.from_dict(table_grid_dict)
+
+    @property
+    def source(self) -> str:
+        """Source of the document, either 'ucsf' or 'pif'."""
+        return self.content["metadata"]["source"]
+
+    @property
+    def original_filename(self) -> str:
+        """
+        Id/filename of the document in the original source.
+
+        Several documents can have the same original_filename if the original pdf was composed of
+        several self-contained documents.
+        """
+        return self.content["metadata"]["original_filename"]
+
+    @property
+    def template_document_id(self) -> str:
+        """
+        Id of the annotated document that was used as a template for the document generation.
+
+        Only available for synthetic documents.
+        """
+        return self.content["metadata"]["template_document_id"]

--- a/tests/data/sample-dataset/annotations/516f2d61ea404b30a9192a72.json
+++ b/tests/data/sample-dataset/annotations/516f2d61ea404b30a9192a72.json
@@ -696,10 +696,13 @@
     "document_type": "tax_invoice",
     "language": "eng",
     "original_filename": "nkvc0055",
-    "page_aspect_ratios": [
-      0.7537993920972644
-    ],
     "page_count": 1,
+    "page_sizes_at_200dpi": [
+      [
+        1692,
+        2245
+      ]
+    ],
     "page_to_table_grid": {
       "0": {
         "bbox": [

--- a/tests/dataset/test_document_annotation.py
+++ b/tests/dataset/test_document_annotation.py
@@ -2,6 +2,46 @@ from docile.dataset.bbox import BBox
 from docile.dataset.dataset import Dataset
 
 
+def test_document_fields_getters(sample_dataset: Dataset, sample_dataset_docid: str) -> None:
+    doc = sample_dataset[sample_dataset_docid]
+    assert len(doc.annotation.fields) == 11
+    assert {f.fieldtype for f in doc.annotation.fields} == {
+        "amount_due",
+        "amount_total_gross",
+        "customer_billing_address",
+        "customer_billing_name",
+        "customer_id",
+        "date_due",
+        "date_issue",
+        "document_id",
+        "payment_reference",
+        "payment_terms",
+        "vendor_name",
+    }
+    assert len(doc.annotation.page_fields(0)) == 11
+    assert doc.annotation.page_fields(1) == []
+
+    assert len(doc.annotation.li_fields) == 40
+    assert {f.line_item_id for f in doc.annotation.li_fields} == set(range(1, 9))
+    assert len(doc.annotation.page_li_fields(0)) == 40
+
+    assert len(doc.annotation.li_headers) == 7
+    assert {f.line_item_id for f in doc.annotation.li_headers} == {0}
+    assert len(doc.annotation.page_li_headers(0)) == 7
+
+
+def test_document_metadata_getters(sample_dataset: Dataset, sample_dataset_docid: str) -> None:
+    doc = sample_dataset[sample_dataset_docid]
+    assert doc.annotation.page_count == 1
+    assert doc.annotation.cluster_id == 554
+    assert doc.annotation.page_image_size_at_200dpi(0) == [1692, 2245]
+    assert doc.annotation.document_type == "tax_invoice"
+    assert doc.annotation.currency == "other"
+    assert doc.annotation.language == "eng"
+    assert doc.annotation.source == "ucsf"
+    assert doc.annotation.original_filename == "nkvc0055"
+
+
 def test_document_annotation_get_table_grid(
     sample_dataset: Dataset, sample_dataset_docid: str
 ) -> None:


### PR DESCRIPTION
Provide getters for all information in annotations. Better describe the page image generation parameter. Remove `page_image_with_fields` which does not belong to document but to some debug tools (it can be added later into `docile/tools/` if we want to have non-interactive versions of some visualizations).