### PR TITLE
Add tutorials, update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,27 @@
 # DocILE: Document Information Localization and Extraction Benchmark
 [![Tests](https://github.com/rossumai/docile/actions/workflows/tests.yml/badge.svg?branch=main)](https://github.com/rossumai/docile/actions/workflows/tests.yml)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
-This repository makes it convenient to work with the DocILE dataset and serves as a starting to point for the DocILE benchmark and CLEF lab/ICDAR competition with a $9000 prize pool that is running from January to May 2023. See more info on the competition website: https://docile.rossum.ai/. The repository consists of:
+Repository to work with the [DocILE dataset and benchmark](https://docile.rossum.ai/), used in the DocILE'23 CLEF Lab and ICDAR Competition.
+The competition deadline is on May 10, 2023 and comes with a **$9000 prize pool**.
+
+The repository consists of:
 * A python library, `docile`, making it easy to load the dataset, work with its annotations, pdfs and pre-computed OCR and run the evaluation.
-* An interactive notebook in [docile/tools/dataset_browser.ipynb](docile/tools/dataset_browser.ipynb) to visualize the dataset documents, annotations, predictions and evaluation results.
-* Baseline solutions intended as a starting point for further research.
+* An interactive [dataset browser notebook](docile/tools/dataset_browser.ipynb) to visualize the document annotations, predictions and evaluation results.
+* Baseline methods (will appear soon).
+
+Table of Contents:
+* [Download the dataset](#download-the-dataset)
+* [Installation](#installation)
+* [Predictions format and running evaluation](#predictions-format-and-running-evaluation)
+* [Pre-computed OCR](#pre-computed-ocr)
+* [Development instructions](#development-instructions)
+
+Also check [Tutorials](tutorials/) to get quickly started with the repo.
 
 ## Download the dataset
 
-First you need to obtain a secret token by following the instructions at https://docile.rossum.ai/.
-
-Then you can use the `download_dataset.sh` script to download the datasets with curl:
+First you need to obtain a secret token by following the instructions at https://docile.rossum.ai/. Then download and unzip the dataset by running:
 ```bash
 ./download_dataset.sh TOKEN annotated-trainval data/docile --unzip
 ./download_dataset.sh TOKEN synthetic data/docile --unzip
@@ -21,15 +32,14 @@ Run `./download_dataset.sh --help` for more options, including how to only show 
 with a different tool than curl), how to download smaller unlabeled/synthetic chunks or unlabeled
 dataset without pdfs (with pre-computed OCR only).
 
-Note that all datasets can be unzipped to the same folder. You can also work with the zipped
-dataset directly in a read-only mode (i.e., caching on disk for images must be turned off).
+You can also work with the zipped datasets when you turn off image caching (check [Load and sample dataset](tutorials/load_and_sample_dataset.md) tutorial for details).
 
 ## Installation
 
 ### Option 1: Install as a library
 To install just the library, download the wheel from the latest release on github and run:
 ```shell
-pip install docile-[...].whl
+pip install docile-0.1.0-py3-none-any.whl
 ```
 
 To convert pdfs into images, the library uses https://github.com/Belval/pdf2image. On linux you might need to install:
@@ -44,17 +54,17 @@ brew install poppler
 
 Now you have all dependencies to work with the dataset annotations, pdfs, pre-comptued OCR and to run the evaluation. You can install extra dependencies by running the following (although using one of the provided dockerfiles, as explained below, might be easier in this case):
 ```shell
-pip install "docile-[...].whl[interactive]"
-pip install "docile-[...].whl[ocr]"
+pip install "docile-0.1.0-py3-none-any.whl[interactive]"
+pip install "docile-0.1.0-py3-none-any.whl[ocr]"
 ```
 
-The first line installs additional dependencies allowing you to use the interactive dataset browser in [docile/tools/dataset_browser.py](docile/tools/dataset_browser.py). The second line let's you rerun the OCR predictions from scratch (e.g., if you'd like to run it with different parameters) but to make it work, you might need additional dependencies on your system. Check https://github.com/mindee/doctr for the installation instructions (for pytorch).
+The first line installs additional dependencies allowing you to use the interactive dataset browser in [docile/tools/dataset_browser.py](docile/tools/dataset_browser.py) and the [tutorials](tutorials/). The second line let's you rerun the OCR predictions from scratch (e.g., if you'd like to run it with different parameters) but to make it work, you might need additional dependencies on your system. Check https://github.com/mindee/doctr for the installation instructions (for pytorch).
 
 ### Option 2: Use docker
 There are two Dockerfiles available with the dependencies preinstalled:
 
 * `Dockerfile` is a lighter, CPU-only, version with all necessary dependencies to use the dataset with the pre-computed OCR and interactive browser.
-* `Dockerfile.gpu` has CUDA GPU support and contains additional dependencies needed to recompute OCR predictions from scratch.
+* `Dockerfile.gpu` has CUDA GPU support and contains additional dependencies needed to recompute OCR predictions from scratch (not needed for standard usage).
 
 You can use docker compose to manage the docker images. First update the settings in `docker-compose.yml` and the port for jupyter lab in `.env`. Then build the image with:
 ```shell
@@ -71,7 +81,7 @@ docker-compose exec jupyter bash
 ```
 After that run `poetry shell` to activate the virtual environment with the `docile` library and its dependencies installed.
 
-## Run Evaluation
+## Predictions format and running evaluation
 
 To evaluate predictions for tasks KILE or LIR, use the following command:
 ```bash
@@ -118,65 +128,9 @@ You can use `docile.dataset.store_predictions` to store predictions represented 
 
 ## Pre-computed OCR
 
-OCR is provided with the dataset. The prediction was done using the [DocTR](https://github.com/mindee/doctr) library.
+Pre-computed OCR is provided with the dataset. The prediction was done using the [DocTR](https://github.com/mindee/doctr) library. On top of that, word boxes were snapped to text (check the code in [docile/dataset/document_ocr.py](docile/dataset/document_ocr.py)). These snapped word boxes are used in evaluation (description of the evaluation is coming soon).
 
-If you wish to (re)generate OCR from scratch (e.g., on a different dataset), delete `DATASET_PATH/ocr` directory and install DocTR. On Mac OS X this can be done using `make install-with-ocr` (resp. `make install-with-ocr-m1` on M1 mac) or by following the official [installation instructions](https://github.com/mindee/doctr#installation).
-
-##  Example usage
-
-Assuming you have your dataset in `data/docile/` with two splits `data/docile/train.json` and `data/docile/test.json`:
-
-```python
-from docile.dataset import Dataset
-from docile.evaluation import evaluate_dataset
-
-# example: take only 10 documents for debugging
-dataset_train = Dataset("train", "data/docile").sample(10, seed=42)
-# equivalently you can load the dataset directly from zip
-dataset_train = Dataset("train", "data/real.zip").sample(10, seed=42)
-
-for document in dataset_train:
-    kile_fields = document.annotation.fields
-    li_fields = document.annotation.li_fields
-    for page in range(document.page_count):
-        img = document.page_image(page)
-        kile_fields_page = [field for field in kile_fields if field.page == page]
-        li_fields_page = [field for field in li_fields if field.page == page]
-        ocr = document.ocr.get_all_words(page)
-        # ...Add to training set...
-
-# ...Train here...
-
-dataset_test = Dataset("test", "data/docile")
-docid_to_kile_predictions = {}
-docid_to_lir_predictions = {}
-for document in dataset_test:
-    # kile_predictions = ... predict KILE fields
-    # lir_predictions = ... predict LIR fields
-    docid_to_kile_predictions[document.docid] = kile_predictions
-    docid_to_lir_predictions[document.docid] = lir_predictions
-
-evaluation_result = evaluate_dataset(dataset_test, docid_to_kile_predictions, docid_to_lir_predictions)
-print(evaluation_result.print_report(include_same_text=True))
-```
-
-When working with a large dataset, such as the unlabeled dataset, do not load the whole dataset to memory:
-
-```python
-from docile.dataset import CachingConfig, Dataset
-
-dataset_unlabeled = Dataset(
-    split_name="pretraining-all",
-    dataset_path="data/docile-unlabeled",
-    load_annotations=False,
-    load_ocr=False,
-    cache_images=CachingConfig.OFF,
-)
-for document in dataset_unlabeled:
-    # temporarily cache document resources in memory.
-    with document:
-        # process document here
-```
+While this should not be needed, it is possible to (re)generate OCR from scratch (including the snapping) with the provided `Dockerfile.gpu`. Just delete `DATASET_PATH/ocr` directory and then access the ocr for each document and page with `doc.ocr.get_all_words(page, snapped=True)`.
 
 ## Development instructions
 
@@ -184,4 +138,4 @@ For development, install [poetry](https://python-poetry.org/docs/) and run `poet
 
 Install pre-commit with `pre-commit install` (don't forget you need to prepend all commands with `poetry run ...` if you did not run `poetry shell` first).
 
-Run tests simply by calling `pytest tests`.
+Run tests by calling `pytest tests`.

--- a/docile/dataset/bbox.py
+++ b/docile/dataset/bbox.py
@@ -28,6 +28,9 @@ class BBox(Generic[T]):
             self.bottom / height,
         )
 
+    def has_valid_relative_coords(self) -> bool:
+        return 0 <= self.left <= self.right <= 1 and 0 <= self.top <= self.bottom <= 1
+
     def to_tuple(self) -> Tuple[T, T, T, T]:
         return self.left, self.top, self.right, self.bottom
 

--- a/docile/dataset/cached_object.py
+++ b/docile/dataset/cached_object.py
@@ -41,6 +41,17 @@ class CachedObject(Generic[CT]):
         self.memory_cache = cache.memory_cache
         self.disk_cache = cache.disk_cache
 
+    def load(self) -> None:
+        self.memory_cache_permanent = True
+        self.memory_cache = True
+        if self._content is None:
+            self.content
+
+    def release(self) -> None:
+        self.memory_cache_permanent = False
+        self.memory_cache = False
+        self._content = None
+
     def __enter__(self) -> "CachedObject":
         self.memory_cache = True
         return self

--- a/docile/dataset/document.py
+++ b/docile/dataset/document.py
@@ -65,15 +65,13 @@ class Document:
         )
         annotation_path = self.data_paths.annotation_path(docid)
         self.annotation = DocumentAnnotation(annotation_path, cache=cache_annotation)
-        if load_annotations:
-            self.annotation.content
 
         cache_ocr = CachingConfig.DISK_AND_MEMORY if load_ocr else CachingConfig.DISK
         ocr_path = self.data_paths.ocr_path(docid)
         pdf_path = self.data_paths.pdf_path(docid)
         self.ocr = DocumentOCR(ocr_path, pdf_path, cache=cache_ocr)
-        if load_ocr:
-            self.ocr.content
+
+        self.load(load_annotations, load_ocr)
 
         self.images = {}
         self.cache_images = cache_images
@@ -82,6 +80,22 @@ class Document:
         self._page_count: Optional[int] = None
 
         self._open = 0
+
+    def load(self, annotations: bool = True, ocr: bool = True) -> "Document":
+        """Load the annotations and/or OCR content to memory."""
+        if annotations:
+            self.annotation.load()
+        if ocr:
+            self.ocr.load()
+        return self
+
+    def release(self, annotations: bool = True, ocr: bool = True) -> "Document":
+        """Free up document resources from memory."""
+        if annotations:
+            self.annotation.release()
+        if ocr:
+            self.ocr.release()
+        return self
 
     @property
     def page_count(self) -> int:

--- a/docile/evaluation/evaluate.py
+++ b/docile/evaluation/evaluate.py
@@ -324,6 +324,16 @@ def _validate_predictions(
             raise PredictionsValidationError(f"{task.upper()}: Prediction is missing 'fieldtype'.")
 
     for task, docid_to_predictions in task_to_docid_to_predictions.items():
+        if any(
+            not pred.bbox.has_valid_relative_coords()
+            for predictions in docid_to_predictions.values()
+            for pred in predictions
+        ):
+            raise PredictionsValidationError(
+                f"{task.upper()}: Prediction bbox does not have valid relative coordinates."
+            )
+
+    for task, docid_to_predictions in task_to_docid_to_predictions.items():
         if task == "kile":
             if any(
                 pred.line_item_id is not None

--- a/tests/dataset/test_dataset.py
+++ b/tests/dataset/test_dataset.py
@@ -11,12 +11,16 @@ def test_dataset_init(sample_dataset_docid: str, sample_dataset_path: Path) -> N
     assert isinstance(dataset[0], Document)
     assert isinstance(dataset[sample_dataset_docid], Document)
 
-    custom_dataset = Dataset("non-existent-split", sample_dataset_path, [sample_dataset_docid])
+    custom_dataset = Dataset(
+        "non-existent-split", sample_dataset_path, docids=[sample_dataset_docid]
+    )
     assert custom_dataset.docids == [sample_dataset_docid]
     # It is possible to give both the index and list of docids if they agree with each other
-    assert dataset.docids == Dataset("dev", sample_dataset_path, [sample_dataset_docid]).docids
+    assert (
+        dataset.docids == Dataset("dev", sample_dataset_path, docids=[sample_dataset_docid]).docids
+    )
 
     with pytest.raises(ValueError):
-        Dataset("dev", sample_dataset_path, ["different-docid"])
+        Dataset("dev", sample_dataset_path, docids=["different-docid"])
     with pytest.raises(ValueError):
         Dataset("non-existent-split", sample_dataset_path)

--- a/tutorials/README.md
+++ b/tutorials/README.md
@@ -1,0 +1,18 @@
+# DocILE tutorials
+
+This folder contains a few examples/tutorials to get familiar with the repository and the dataset:
+
+* [Quickstart](quickstart.md): Showcase the basic functionality of the repo -- load dataset, create dummy predictions, run & visualize evaluation.
+* [Load and Sample Dataset](load_and_sample_dataset.md): Useful overview of how to load the dataset, working efficiently with small & large datasets and their subsets.
+
+Also check [Dataset Browser Notebook](../docile/tools/dataset_browser.ipynb) to browse through the data.
+
+## Editing the tutorials
+
+To edit the tutorials follow these steps (to prevent committing large files in git):
+
+* Make the changes in the jupyter notebook and run all cells.
+* Export the markdown file from jupyter lab with `File -> Save and Export Notebook As... -> Markdown`
+* Add `*Generated from [ntb.ipynb](ntb.ipynb)*` at the top of the markdown file. Limit other changes in the markdown output to minimum so that future edits of the tutorials remain simple.
+* Do not add images to git. Instead create a pull request and edit the markdown files directly on github, uploading the images there.
+* Clear all outputs in jupyter notebook before adding it to git.

--- a/tutorials/load_and_sample_dataset.ipynb
+++ b/tutorials/load_and_sample_dataset.ipynb
@@ -1,0 +1,360 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "bca11a49-551d-49bb-970b-460313d13c22",
+   "metadata": {},
+   "source": [
+    "# Tutorial: Load and Sample Datasets"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "e6f4c13d-af8e-4dd4-bdc0-8701922cc757",
+   "metadata": {},
+   "source": [
+    "In this tutorial you will learn what are the different ways to load datasets, subsample them.\n",
+    "\n",
+    "To run all cells, you need the `annotated-trainval` and `synthetic` datasets unzipped in `data/docile` and `annotated-trainval.zip` file in `data/`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "daf865fb-be3d-4243-b261-7b6b8c46bf6d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from docile.dataset import CachingConfig, Dataset\n",
+    "\n",
+    "DATASET_PATH = Path(\"/app/data/docile/\")\n",
+    "DATASET_PATH_ZIP = Path(\"/app/data/annotated-trainval.zip\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9e17c01c-9d6f-48d6-9bff-02f73244bdfd",
+   "metadata": {},
+   "source": [
+    "## Load from folder with unzipped dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93784f80-98e2-4375-9df0-3e0dcec0fd51",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "val = Dataset(\"val\", DATASET_PATH)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9b26393b-dd4a-42e2-87fb-7fc154d1efab",
+   "metadata": {},
+   "source": [
+    "## Load from zip"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4f82f329-f545-4303-a4de-720ef8ecd66e",
+   "metadata": {},
+   "source": [
+    "Dataset can be loaded directly from zip as well but image caching to disk must be turned off."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a09ffdb3-93bc-4ffc-9b13-d4770157fa73",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "val = Dataset(\"val\", DATASET_PATH_ZIP, cache_images=CachingConfig.OFF)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "f77805d5-513e-45b3-aa29-d721a8315a76",
+   "metadata": {},
+   "source": [
+    "## Preloading document resources to memory and image caching"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bca6070d-59f4-41e4-976c-a69262638e24",
+   "metadata": {},
+   "source": [
+    "By default, dataset is loaded with these settings:\n",
+    "\n",
+    "* annotations and pre-computed OCR are loaded to memory\n",
+    "* images generated from PDFs are cached to disk (for faster access of the images in future iterations)\n",
+    "\n",
+    "Below you see options how to change this default behaviour, which is especially useful for large datasets."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "04ad98f3-ca23-4abb-8d40-075c396bed2a",
+   "metadata": {},
+   "source": [
+    "**Only load annotations, not pre-computed OCR**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2bdbdca9-5c01-4975-ab6f-850e333a2026",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "train = Dataset(\"train\", DATASET_PATH, load_ocr=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4ce69236-b160-479b-8d34-892f30550d72",
+   "metadata": {},
+   "source": [
+    "**Postpone loading of document resources**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "8a1bdfe1-c42d-4d06-8566-b15bdec8ab65",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Do not preload document resources\n",
+    "synthetic = Dataset(\"synthetic\", DATASET_PATH, load_annotations=False, load_ocr=False, cache_images=CachingConfig.OFF)\n",
+    "# You can load part of the dataset later\n",
+    "synthetic_sample = synthetic[:100].load()\n",
+    "# And release it from memory later\n",
+    "synthetic_sample.release()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0725f950-4cf3-427a-a6b6-1bedda063f95",
+   "metadata": {},
+   "source": [
+    "**Cache images to both disk and memory**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a5ee58b4-8b6d-4a9e-9f9b-858a0403be0e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Cache images also in memory. Make sure you have enough RAM memory to do this!\n",
+    "# Images are not loaded to memory right away but only after first\n",
+    "train = Dataset(\"train\", DATASET_PATH, cache_images=CachingConfig.DISK_AND_MEMORY)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "7d8456a0-7a3c-42f0-b368-dfb1bbbc6b29",
+   "metadata": {},
+   "source": [
+    "## Sample and chunk documents"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bcb21a02-da04-4aa8-9ae0-d430f9fc9a82",
+   "metadata": {},
+   "source": [
+    "For experiments and to work with large datasets, it can be useful to take samples of the datasets.\n",
+    "\n",
+    "For this, you can use slicing `[start:end:step]`, `.sample()`, `.get_cluster()` or `.from_documents()` methods."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a69741c7-4b10-4409-86e9-2986a59b3057",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "synthetic = Dataset(\"synthetic\", DATASET_PATH, load_annotations=False, load_ocr=False, cache_images=CachingConfig.OFF)\n",
+    "trainval = Dataset(\"trainval\", DATASET_PATH, load_annotations=False, load_ocr=False, cache_images=CachingConfig.OFF)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9621d77e-5820-4b2b-967f-98771468c07d",
+   "metadata": {},
+   "source": [
+    "**Slicing**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0c9cab7d-ac31-4cd3-a3c0-07ae91001cb7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Synthetic document has 100 chunks of 1000 documents from the same template document, so the\n",
+    "# following line selects 1 document for each template document:\n",
+    "synthetic_slice = synthetic[8::1000]\n",
+    "print(synthetic_slice.docids[:5])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "788090cc-d536-4cc3-8df3-9e43acd4d598",
+   "metadata": {},
+   "source": [
+    "**Random sample**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "20041b46-49f5-475c-9fcb-ff2dea15ba2a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "synthetic_sample = synthetic.sample(5)\n",
+    "print(synthetic_sample)\n",
+    "print(synthetic_sample.docids)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "263df176-3366-4a25-8ee3-34d722ef0c79",
+   "metadata": {},
+   "source": [
+    "**Documents belonging to the same cluster**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "3026aabd-c303-4e0a-aced-4d6501b8a4d7",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainval_cluster = trainval.get_cluster(synthetic[0].annotation.cluster_id)\n",
+    "print(f\"Found {len(trainval_cluster)} documents in {trainval_cluster}.\")\n",
+    "\n",
+    "from PIL import Image\n",
+    "\n",
+    "print(\"Showing 10 images from the cluster:\")\n",
+    "imgs = [doc.page_image(page=0, image_size=(None, 100)) for doc in trainval_cluster[:10]]\n",
+    "concat_img = Image.new(\"RGB\", (sum(img.width for img in imgs), 100))\n",
+    "start_from = 0\n",
+    "for img in imgs:\n",
+    "    concat_img.paste(img, (start_from, 0))\n",
+    "    start_from += img.width\n",
+    "concat_img"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "6928e572-09c7-4637-b2a2-40f2e2967950",
+   "metadata": {},
+   "source": [
+    "**Using custom filter**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0724681f-9a13-4a8a-bad9-5c10b3473a16",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainval_ucsf = Dataset.from_documents(\"trainval-ucsf\", [doc for doc in trainval if doc.annotation.source == \"ucsf\"])\n",
+    "trainval_pif = Dataset.from_documents(\"trainval-pif\", [doc for doc in trainval if doc.annotation.source == \"pif\"])\n",
+    "print(f\"{trainval_ucsf} with {len(trainval_ucsf)} documents\")\n",
+    "print(f\"{trainval_pif} with {len(trainval_pif)} documents\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "0999723a-e164-4bf4-9409-bcc68a458989",
+   "metadata": {},
+   "source": [
+    "## Chunk dataset into parts with the same number of pages"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bf55f32c-1fc9-4291-be19-c1c3d6a384e6",
+   "metadata": {},
+   "source": [
+    "Create dataset chunks that have a limited number of pages. This can be especially useful for large datasets, such as the unlabeled dataset."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0bed2781-b19e-4ce5-9270-0c000a2647a9",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from typing import Iterable\n",
+    "\n",
+    "def chunk_dataset(dataset: Dataset, max_pages_per_chunk: int) -> Iterable[Dataset]:\n",
+    "    start_doc_i = 0\n",
+    "    pages = 0\n",
+    "    for doc_i, document in enumerate(dataset.documents):\n",
+    "        documents = doc_i - start_doc_i + 1\n",
+    "        pages += document.page_count\n",
+    "        if doc_i > start_doc_i and pages > max_pages_per_chunk:\n",
+    "            yield dataset[start_doc_i:doc_i]\n",
+    "            start_doc_i = doc_i\n",
+    "            pages = document.page_count\n",
+    "    yield dataset[start_doc_i:]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "c3645bee-c173-49aa-b301-2b4e1fd49b21",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "trainval = Dataset(\"trainval\", DATASET_PATH, load_annotations=False, load_ocr=False, cache_images=CachingConfig.OFF)\n",
+    "\n",
+    "max_pages_per_chunk = 2000\n",
+    "\n",
+    "for chunk in chunk_dataset(trainval, max_pages_per_chunk):\n",
+    "    print(f\"{chunk}, pages: {chunk.total_page_count()}\")\n",
+    "    chunk.load(annotations=True, ocr=False)\n",
+    "    # ... work with the chunk here ...\n",
+    "    chunk.release() # don't forget to free up the memory"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/load_and_sample_dataset.md
+++ b/tutorials/load_and_sample_dataset.md
@@ -1,0 +1,228 @@
+*Generated from [load_and_sample_dataset.ipynb](load_and_sample_dataset.ipynb)*
+
+# Tutorial: Load and Sample Datasets
+
+In this tutorial you will learn what are the different ways to load datasets, subsample them.
+
+To run all cells, you need the `annotated-trainval` and `synthetic` datasets unzipped in `data/docile` and `annotated-trainval.zip` file in `data/`.
+
+
+```python
+from pathlib import Path
+from docile.dataset import CachingConfig, Dataset
+
+DATASET_PATH = Path("/app/data/docile/")
+DATASET_PATH_ZIP = Path("/app/data/annotated-trainval.zip")
+```
+
+## Load from folder with unzipped dataset
+
+
+```python
+val = Dataset("val", DATASET_PATH)
+```
+
+    Loading documents for docile:val: 100%|██████████| 500/500 [00:03<00:00, 145.04it/s]
+
+
+## Load from zip
+
+Dataset can be loaded directly from zip as well but image caching to disk must be turned off.
+
+
+```python
+val = Dataset("val", DATASET_PATH_ZIP, cache_images=CachingConfig.OFF)
+```
+
+    Loading documents for annotated-trainval.zip:val: 100%|██████████| 500/500 [00:01<00:00, 281.09it/s]
+
+
+## Preloading document resources to memory and image caching
+
+By default, dataset is loaded with these settings:
+
+* annotations and pre-computed OCR are loaded to memory
+* images generated from PDFs are cached to disk (for faster access of the images in future iterations)
+
+Below you see options how to change this default behaviour, which is especially useful for large datasets.
+
+**Only load annotations, not pre-computed OCR**
+
+
+```python
+train = Dataset("train", DATASET_PATH, load_ocr=False)
+```
+
+    Loading documents for docile:train: 100%|██████████| 5180/5180 [00:08<00:00, 634.19it/s]
+
+
+**Postpone loading of document resources**
+
+
+```python
+# Do not preload document resources
+synthetic = Dataset("synthetic", DATASET_PATH, load_annotations=False, load_ocr=False, cache_images=CachingConfig.OFF)
+# You can load part of the dataset later
+synthetic_sample = synthetic[:100].load()
+# And release it from memory later
+synthetic_sample.release()
+```
+
+    Initializing documents for docile:synthetic: 100%|██████████| 100000/100000 [00:03<00:00, 31701.69it/s]
+    Loading documents for docile:synthetic[:100]: 100%|██████████| 100/100 [00:00<00:00, 220.34it/s]
+
+
+**Cache images to both disk and memory**
+
+
+```python
+# Cache images also in memory. Make sure you have enough RAM memory to do this!
+# Images are not loaded to memory right away but only after first
+train = Dataset("train", DATASET_PATH, cache_images=CachingConfig.DISK_AND_MEMORY)
+```
+
+    Loading documents for docile:train: 100%|██████████| 5180/5180 [00:42<00:00, 122.97it/s]
+
+
+## Sample and chunk documents
+
+For experiments and to work with large datasets, it can be useful to take samples of the datasets.
+
+For this, you can use slicing `[start:end:step]`, `.sample()`, `.get_cluster()` or `.from_documents()` methods.
+
+
+```python
+synthetic = Dataset("synthetic", DATASET_PATH, load_annotations=False, load_ocr=False, cache_images=CachingConfig.OFF)
+trainval = Dataset("trainval", DATASET_PATH, load_annotations=False, load_ocr=False, cache_images=CachingConfig.OFF)
+```
+
+    Initializing documents for docile:synthetic: 100%|██████████| 100000/100000 [00:02<00:00, 41461.39it/s]
+
+
+**Slicing**
+
+
+```python
+# Synthetic document has 100 chunks of 1000 documents from the same template document, so the
+# following line selects 1 document for each template document:
+synthetic_slice = synthetic[8::1000]
+print(synthetic_slice.docids[:5])
+```
+
+    ['synthetic-02a50adccac54a569011f167-008', 'synthetic-04cb9c50d4c949598689ea6f-008', 'synthetic-062d94841d1649a5b5a4e720-008', 'synthetic-1239abc177b245dfae0145d9-008', 'synthetic-141c3120d0f54beeb771d411-008']
+
+
+**Random sample**
+
+
+```python
+synthetic_sample = synthetic.sample(5)
+print(synthetic_sample)
+print(synthetic_sample.docids)
+```
+
+    Dataset(docile:synthetic[sample(5,seed=15980735705623844408)])
+    ['synthetic-29639c44ca7f43ad8739bd62-825', 'synthetic-698c58c5ece74fc9971d2f64-769', 'synthetic-f079d766ab2841b4956aef79-064', 'synthetic-89679c3d35524159b431d16a-816', 'synthetic-ef9e2ae7d518402982dbcb99-384']
+
+
+**Documents belonging to the same cluster**
+
+
+```python
+trainval_cluster = trainval.get_cluster(synthetic[0].annotation.cluster_id)
+print(f"Found {len(trainval_cluster)} documents in {trainval_cluster}.")
+
+from PIL import Image
+
+print("Showing 10 images from the cluster:")
+imgs = [doc.page_image(page=0, image_size=(None, 100)) for doc in trainval_cluster[:10]]
+concat_img = Image.new("RGB", (sum(img.width for img in imgs), 100))
+start_from = 0
+for img in imgs:
+    concat_img.paste(img, (start_from, 0))
+    start_from += img.width
+concat_img
+```
+
+    Found 29 documents in Dataset(docile:trainval[cluster_id=765]).
+    Showing 10 images from the cluster:
+
+
+
+
+
+
+![output_24_1](https://user-images.githubusercontent.com/1220288/215839029-2b7fb0ff-8c36-4201-a69d-60760d17a300.png)
+
+
+
+**Using custom filter**
+
+
+```python
+trainval_ucsf = Dataset.from_documents("trainval-ucsf", [doc for doc in trainval if doc.annotation.source == "ucsf"])
+trainval_pif = Dataset.from_documents("trainval-pif", [doc for doc in trainval if doc.annotation.source == "pif"])
+print(f"{trainval_ucsf} with {len(trainval_ucsf)} documents")
+print(f"{trainval_pif} with {len(trainval_pif)} documents")
+```
+
+    Dataset(docile:trainval-ucsf) with 2645 documents
+    Dataset(docile:trainval-pif) with 3035 documents
+
+
+## Chunk dataset into parts with the same number of pages
+
+Create dataset chunks that have a limited number of pages. This can be especially useful for large datasets, such as the unlabeled dataset.
+
+
+```python
+from typing import Iterable
+
+def chunk_dataset(dataset: Dataset, max_pages_per_chunk: int) -> Iterable[Dataset]:
+    start_doc_i = 0
+    pages = 0
+    for doc_i, document in enumerate(dataset.documents):
+        documents = doc_i - start_doc_i + 1
+        pages += document.page_count
+        if doc_i > start_doc_i and pages > max_pages_per_chunk:
+            yield dataset[start_doc_i:doc_i]
+            start_doc_i = doc_i
+            pages = document.page_count
+    yield dataset[start_doc_i:]
+```
+
+
+```python
+trainval = Dataset("trainval", DATASET_PATH, load_annotations=False, load_ocr=False, cache_images=CachingConfig.OFF)
+
+max_pages_per_chunk = 2000
+
+for chunk in chunk_dataset(trainval, max_pages_per_chunk):
+    print(f"{chunk}, pages: {chunk.total_page_count()}")
+    chunk.load(annotations=True, ocr=False)
+    # ... work with the chunk here ...
+    chunk.release() # don't forget to free up the memory
+```
+
+    Dataset(docile:trainval[0:1530]), pages: 1999
+
+
+    Loading documents for docile:trainval[0:1530]: 100%|██████████| 1530/1530 [00:02<00:00, 660.47it/s]
+
+
+    Dataset(docile:trainval[1530:3051]), pages: 2000
+
+
+    Loading documents for docile:trainval[1530:3051]: 100%|██████████| 1521/1521 [00:02<00:00, 665.22it/s]
+
+
+    Dataset(docile:trainval[3051:4584]), pages: 2000
+
+
+    Loading documents for docile:trainval[3051:4584]: 100%|██████████| 1533/1533 [00:02<00:00, 654.72it/s]
+
+
+    Dataset(docile:trainval[4584:]), pages: 1395
+
+
+    Loading documents for docile:trainval[4584:]: 100%|██████████| 1096/1096 [00:01<00:00, 613.10it/s]

--- a/tutorials/quickstart.ipynb
+++ b/tutorials/quickstart.ipynb
@@ -1,0 +1,405 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "8177cbcb-b60c-484b-b10c-1b267e6e9cd8",
+   "metadata": {},
+   "source": [
+    "# Quickstart: From dataset to predictions and evaluation\n",
+    "\n",
+    "This tutorial works with a sample dataset (with only one document) that is present in the repo (no need to download anything). To see how to properly work with larger datasets, check [Load and Sample Dataset](load_and_sample_dataset.md) tutorial."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "4cc7cda7-5eb8-4faf-b616-620fc7693118",
+   "metadata": {},
+   "source": [
+    "## Load sample dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2493c86a-3ab0-4d0d-bf86-b1f61e93b6f3",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pathlib import Path\n",
+    "from docile.dataset import CachingConfig, Dataset\n",
+    "\n",
+    "DATASET_PATH = Path(\"/app/tests/data/sample-dataset/\")\n",
+    "sample_dataset = Dataset(\"dev\", DATASET_PATH)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "45f4562f-ebb2-4c5d-a966-bb5ab635db30",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"{sample_dataset} with {len(sample_dataset)} docs and {sample_dataset.total_page_count()} pages\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a993cafb-ae3e-4a21-84f8-c9a67b31653d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_doc = sample_dataset[0]\n",
+    "print(sample_doc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "d883ec87-1b83-4aa2-af65-3f4566ca991d",
+   "metadata": {},
+   "source": [
+    "## Browse available document resources"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "76c0bdf0-7249-405f-9400-19cdae6f775b",
+   "metadata": {},
+   "source": [
+    "**Read pdf and convert it to image**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "b118147f-83cc-4fa9-badb-834d53357016",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pdf_bytes = sample_doc.data_paths.pdf_path(sample_doc.docid).read_bytes()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "061d5264-a23b-43c0-ae0f-7de4fa22f4f0",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "pdf_bytes[:20]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c919455f-eb56-4874-8cdd-edd064be987f",
+   "metadata": {},
+   "source": [
+    "Convert to image with a width set to 500 pixels."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "93790d69-6907-4f28-a9ad-aedfbb09d463",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sample_doc.page_image(page=0, image_size=(500, None))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "9cad8ad1-d376-4cf0-93c9-5bf6fb3f84fe",
+   "metadata": {},
+   "source": [
+    "**Access & visualize annotations**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "44f4877d-9dfc-4433-ba63-4b180ca6ba6e",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(f\"{sample_doc.annotation.fields[0]=}\\n\")\n",
+    "print(f\"{sample_doc.annotation.li_fields[0]=}\\n\")\n",
+    "print(f\"{sample_doc.annotation.li_headers[0]=}\\n\")\n",
+    "print(f\"{sample_doc.annotation.cluster_id=}\")\n",
+    "print(f\"{sample_doc.annotation.document_type=}\")\n",
+    "print(f\"{len(sample_doc.annotation.get_table_grid(page=0).rows_bbox_with_type)=}\")\n",
+    "print()\n",
+    "print(\"Access raw annotations dictionary:\")\n",
+    "print(f\"{sample_doc.annotation.content.keys()=}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bdf07a60-0a26-4d4f-9b1e-edab08ebbb28",
+   "metadata": {},
+   "source": [
+    "Show annotations in the dataset browser"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "4ea35e9d-3fbd-4287-857f-ed6d4677427f",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from docile.tools.dataset_browser import DatasetBrowser\n",
+    "\n",
+    "browser = DatasetBrowser(sample_dataset)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c92bb6c5-08d3-45bb-85e9-5588b7c7a954",
+   "metadata": {},
+   "source": [
+    "**Access Pre-computed OCR**\n",
+    "\n",
+    "Word tokens of the pre-computed OCR can be easily accessed in two variants, with `snapped=False` and `snapped=True`. The first version is computed by DocTR and the second version uses some heuristics to remove whitespace around the edges of the predictions. The snapped OCR word boxes are also used to generate the Pseudo-Character-Centers which are used in evaluation (check the dataset paper or code for details)."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "557e8ec8-06ce-4079-af08-dfce3d87f338",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "words = sample_doc.ocr.get_all_words(page=0)\n",
+    "snapped_words = sample_doc.ocr.get_all_words(page=0, snapped=True)\n",
+    "print(words[0])\n",
+    "print(snapped_words[0])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "830c23e0-4b21-4e4d-9e3b-da64eef2a219",
+   "metadata": {},
+   "source": [
+    "Show crop of the document page with pre-computed OCR words. Blue boxes are the original boxes, red boxes are the snapped boxes"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a00d4857-a08c-42d7-b418-7a10b95d4c8a",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from PIL import ImageDraw\n",
+    "\n",
+    "page_img = sample_doc.page_image(0, image_size=(1600, None))\n",
+    "\n",
+    "draw_img = page_img.copy()\n",
+    "draw = ImageDraw.Draw(draw_img, \"RGB\")\n",
+    "for word in sample_doc.ocr.get_all_words(page=0, snapped=False):\n",
+    "    scaled_bbox = word.bbox.to_absolute_coords(*draw_img.size)\n",
+    "    draw.rectangle(scaled_bbox.to_tuple(), outline=\"blue\")\n",
+    "for word in sample_doc.ocr.get_all_words(page=0, snapped=True):\n",
+    "    scaled_bbox = word.bbox.to_absolute_coords(*draw_img.size)\n",
+    "    draw.rectangle(scaled_bbox.to_tuple(), outline=\"red\")\n",
+    "draw_img.crop((680, 480, 950, 580))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c1dd53f9-60ed-46d7-9a2f-62338bd0d9d0",
+   "metadata": {},
+   "source": [
+    "Access raw OCR content"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "afa6166a-8b25-4149-b768-22ae30760310",
+   "metadata": {
+    "tags": []
+   },
+   "outputs": [],
+   "source": [
+    "ocr_dict = sample_doc.ocr.content\n",
+    "ocr_dict[\"pages\"][0][\"blocks\"][4]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "174ff41e-34e6-42f0-a88b-0d6a675677cf",
+   "metadata": {},
+   "source": [
+    "## Create dummy predictions"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "350f43f4-45f3-41e6-806d-3f4478733f9f",
+   "metadata": {},
+   "source": [
+    "Create predictions as perturbations of the gold labels (just as example). Some labels are thrown away and for some labels, two predictions are created instead of one."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "2254249c-00e0-4b42-93c1-24772b7c0a43",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from dataclasses import replace\n",
+    "from random import Random\n",
+    "from typing import List, Sequence, Tuple\n",
+    "\n",
+    "from docile.dataset import BBox, Document, Field\n",
+    "\n",
+    "def fields_perturbation(rng: Random, fields: Sequence[Field], max_shift: Tuple[float, float]) -> List[Field]:\n",
+    "    new_fields = []\n",
+    "    for field in fields:\n",
+    "        p = rng.random()\n",
+    "        generate_fields = 1\n",
+    "        if p < 0.2:\n",
+    "            generate_fields = 0\n",
+    "        elif p > 0.9:\n",
+    "            generate_fields = 2\n",
+    "        for _ in range(generate_fields):\n",
+    "            max_shift_horizontal, max_shift_vertical = max_shift\n",
+    "            left = field.bbox.left + (rng.random() * 2 - 1) * max_shift_horizontal\n",
+    "            right = field.bbox.right + (rng.random() * 2 - 1) * max_shift_horizontal\n",
+    "            if right < left:\n",
+    "                left, right = right, left\n",
+    "            top = field.bbox.top + (rng.random() * 2 - 1) * max_shift_vertical\n",
+    "            bottom = field.bbox.bottom + (rng.random() * 2 - 1) * max_shift_vertical\n",
+    "            if bottom < top:\n",
+    "                top, bottom = bottom, top\n",
+    "            new_field = replace(field, bbox=BBox(left, top, right, bottom))\n",
+    "            new_fields.append(new_field)\n",
+    "    return new_fields\n",
+    "        \n",
+    "def get_max_shift_in_relative_coords(doc: Document, max_shift_px_at_200dpi: Tuple[int, int]) -> Tuple[float, float]:\n",
+    "    size_at_200dpi = doc.page_image_size(page=0, dpi=200)\n",
+    "    return (max_shift_px_at_200dpi[0] / size_at_200dpi[0], max_shift_px_at_200dpi[1] / size_at_200dpi[1])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "0389ec2b-352b-4cd7-8941-897755e7854d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "rng = Random(42)\n",
+    "\n",
+    "max_shift = get_max_shift_in_relative_coords(sample_doc, max_shift_px_at_200dpi=(15, 5))\n",
+    "kile_predictions = {sample_doc.docid: fields_perturbation(rng, sample_doc.annotation.fields, max_shift)}\n",
+    "lir_predictions = {sample_doc.docid: fields_perturbation(rng, sample_doc.annotation.li_fields, max_shift)}"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "bb4558af-4e87-42a8-8dad-cc86fbbab79d",
+   "metadata": {},
+   "source": [
+    "**Store predictions to json**\n",
+    "\n",
+    "In this format predictions are submitted to the benchmark. With the predictions stored on disk you can also run the evaluation from command line with `docile_evaluate` command."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "a92e88a6-a595-487b-9658-5846dca4b47d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from docile.dataset import store_predictions\n",
+    "\n",
+    "store_predictions(Path(\"/tmp/kile-perturbations.json\"), kile_predictions)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "5c02db0d-d287-4fd1-a156-ae76c0f27003",
+   "metadata": {},
+   "source": [
+    "**Run evaluation**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "300848d4-a189-4f55-b85e-abc7d8acf420",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from docile.evaluation import evaluate_dataset\n",
+    "\n",
+    "evaluation_result = evaluate_dataset(sample_dataset, kile_predictions, lir_predictions)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "97ddfa00-cb77-434d-a37e-67ada6245af6",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "print(evaluation_result.print_report())"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ae7fd8ff-3fdb-4d5c-adea-d10addbfeb9c",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "evaluation_result.get_primary_metric(\"kile\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "09249bee-7857-4743-84bd-94d6156d5c24",
+   "metadata": {},
+   "source": [
+    "**Visualize matching**"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "771d46f9-c728-483a-94a7-3a664512fec4",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kile_matching = evaluation_result.task_to_docid_to_matching[\"kile\"]\n",
+    "lir_matching = evaluation_result.task_to_docid_to_matching[\"lir\"]\n",
+    "DatasetBrowser(sample_dataset, kile_matching=kile_matching, lir_matching=lir_matching)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.10.9"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/tutorials/quickstart.md
+++ b/tutorials/quickstart.md
@@ -1,0 +1,385 @@
+*Generated from [quickstart.ipynb](quickstart.ipynb)*
+
+# Quickstart: From dataset to predictions and evaluation
+
+This tutorial works with a sample dataset (with only one document) that is present in the repo (no need to download anything). To see how to properly work with larger datasets, check [Load and Sample Dataset](load_and_sample_dataset.md) tutorial.
+
+## Load sample dataset
+
+
+```python
+from pathlib import Path
+from docile.dataset import CachingConfig, Dataset
+
+DATASET_PATH = Path("/app/tests/data/sample-dataset/")
+sample_dataset = Dataset("dev", DATASET_PATH)
+```
+
+    Loading documents for sample-dataset:dev: 100%|██████████| 1/1 [00:00<00:00, 33.06it/s]
+
+
+
+```python
+print(f"{sample_dataset} with {len(sample_dataset)} docs and {sample_dataset.total_page_count()} pages")
+```
+
+    Dataset(sample-dataset:dev) with 1 docs and 1 pages
+
+
+
+```python
+sample_doc = sample_dataset[0]
+print(sample_doc)
+```
+
+    Document(sample-dataset:516f2d61ea404b30a9192a72)
+
+
+## Browse available document resources
+
+**Read pdf and convert it to image**
+
+
+```python
+pdf_bytes = sample_doc.data_paths.pdf_path(sample_doc.docid).read_bytes()
+```
+
+
+```python
+pdf_bytes[:20]
+```
+
+
+
+
+    b'%PDF-1.3\n%\x8f\n1 0 obj\n'
+
+
+
+Convert to image with a width set to 500 pixels.
+
+
+```python
+sample_doc.page_image(page=0, image_size=(500, None))
+```
+
+
+
+
+![output_10_0](https://user-images.githubusercontent.com/1220288/215839370-09123aa2-1633-4fba-9df6-baba8f501cb7.png)
+
+
+
+
+**Access & visualize annotations**
+
+
+```python
+print(f"{sample_doc.annotation.fields[0]=}\n")
+print(f"{sample_doc.annotation.li_fields[0]=}\n")
+print(f"{sample_doc.annotation.li_headers[0]=}\n")
+print(f"{sample_doc.annotation.cluster_id=}")
+print(f"{sample_doc.annotation.document_type=}")
+print(f"{len(sample_doc.annotation.get_table_grid(page=0).rows_bbox_with_type)=}")
+print()
+print("Access raw annotations dictionary:")
+print(f"{sample_doc.annotation.content.keys()=}")
+```
+
+    sample_doc.annotation.fields[0]=Field(bbox=BBox(left=0.8201612903225807, top=0.19939209726443768, right=0.8838709677419355, bottom=0.20972644376899696), page=0, text='99999999', fieldtype='document_id')
+
+    sample_doc.annotation.li_fields[0]=Field(bbox=BBox(left=0.12580645161290321, top=0.3884498480243161, right=0.14112903225806453, bottom=0.4006079027355623), page=0, text='4', fieldtype='line_item_quantity', line_item_id=1)
+
+    sample_doc.annotation.li_headers[0]=Field(bbox=BBox(left=0.11370967741935484, top=0.35303951367781156, right=0.15564516129032258, bottom=0.3700607902735562), page=0, text='NUMBER\nOF CASES', fieldtype='line_item_quantity', line_item_id=0)
+
+    sample_doc.annotation.cluster_id=554
+    sample_doc.annotation.document_type='tax_invoice'
+    len(sample_doc.annotation.get_table_grid(page=0).rows_bbox_with_type)=17
+
+    Access raw annotations dictionary:
+    sample_doc.annotation.content.keys()=dict_keys(['field_extractions', 'line_item_extractions', 'line_item_headers', 'metadata'])
+
+
+Show annotations in the dataset browser
+
+
+```python
+from docile.tools.dataset_browser import DatasetBrowser
+
+browser = DatasetBrowser(sample_dataset)
+```
+
+![newplot (2)](https://user-images.githubusercontent.com/1220288/215839577-11272f65-68d8-4ca8-be42-b5fcfb092343.png)
+
+
+**Access Pre-computed OCR**
+
+Word tokens of the pre-computed OCR can be easily accessed in two variants, with `snapped=False` and `snapped=True`. The first version is computed by DocTR and the second version uses some heuristics to remove whitespace around the edges of the predictions. The snapped OCR word boxes are also used to generate the Pseudo-Character-Centers which are used in evaluation (check the dataset paper or code for details).
+
+
+```python
+words = sample_doc.ocr.get_all_words(page=0)
+snapped_words = sample_doc.ocr.get_all_words(page=0, snapped=True)
+print(words[0])
+print(snapped_words[0])
+```
+
+    Field(bbox=BBox(left=0.353515625, top=0.1171875, right=0.4931640625, bottom=0.1484375), page=0, text='PHILIP')
+    Field(bbox=BBox(left=0.3540189125295508, top=0.11804008908685969, right=0.4929078014184397, bottom=0.14788418708240533), page=0, text='PHILIP')
+
+
+Show crop of the document page with pre-computed OCR words. Blue boxes are the original boxes, red boxes are the snapped boxes
+
+
+```python
+from PIL import ImageDraw
+
+page_img = sample_doc.page_image(0, image_size=(1600, None))
+
+draw_img = page_img.copy()
+draw = ImageDraw.Draw(draw_img, "RGB")
+for word in sample_doc.ocr.get_all_words(page=0, snapped=False):
+    scaled_bbox = word.bbox.to_absolute_coords(*draw_img.size)
+    draw.rectangle(scaled_bbox.to_tuple(), outline="blue")
+for word in sample_doc.ocr.get_all_words(page=0, snapped=True):
+    scaled_bbox = word.bbox.to_absolute_coords(*draw_img.size)
+    draw.rectangle(scaled_bbox.to_tuple(), outline="red")
+draw_img.crop((680, 480, 950, 580))
+```
+
+
+
+
+![output_18_0](https://user-images.githubusercontent.com/1220288/215839449-22da9cbb-bae9-467e-84bb-6052d7d45838.png)
+
+
+
+
+Access raw OCR content
+
+
+```python
+ocr_dict = sample_doc.ocr.content
+ocr_dict["pages"][0]["blocks"][4]
+```
+
+
+
+
+    {'geometry': [[0.4365234375, 0.2275390625], [0.58984375, 0.2705078125]],
+     'lines': [{'geometry': [[0.48046875, 0.2275390625],
+        [0.5439453125, 0.2392578125]],
+       'words': [{'value': 'Marlboro',
+         'confidence': 0.9411603212356567,
+         'geometry': [[0.48046875, 0.2275390625], [0.5439453125, 0.2392578125]],
+         'snapped_geometry': [[0.48226950354609927, 0.2285077951002227],
+          [0.5425531914893617, 0.2374164810690423]]}]},
+      {'geometry': [[0.4365234375, 0.2412109375], [0.58984375, 0.255859375]],
+       'words': [{'value': 'February',
+         'confidence': 0.7711520195007324,
+         'geometry': [[0.4365234375, 0.2412109375], [0.4990234375, 0.255859375]],
+         'snapped_geometry': [[0.4379432624113475, 0.24276169265033407],
+          [0.49763593380614657, 0.2543429844097996]]},
+        {'value': 'B3G2F',
+         'confidence': 0.9990770816802979,
+         'geometry': [[0.5, 0.2421875], [0.5478515625, 0.25390625]],
+         'snapped_geometry': [[0.5011820330969267, 0.24320712694877505],
+          [0.5466903073286052, 0.2525612472160356]]},
+        {'value': 'Packs',
+         'confidence': 0.9998856782913208,
+         'geometry': [[0.548828125, 0.2421875], [0.58984375, 0.25390625]],
+         'snapped_geometry': [[0.5508274231678487, 0.24276169265033407],
+          [0.5868794326241135, 0.2516703786191537]]}]},
+      {'geometry': [[0.4599609375, 0.255859375], [0.564453125, 0.2705078125]],
+       'words': [{'value': 'Sample',
+         'confidence': 0.9984312653541565,
+         'geometry': [[0.4599609375, 0.255859375], [0.51171875, 0.2705078125]],
+         'snapped_geometry': [[0.4627659574468085, 0.2574610244988864],
+          [0.5094562647754137, 0.2681514476614699]]},
+        {'value': 'Invoice',
+         'confidence': 0.99850994348526,
+         'geometry': [[0.5126953125, 0.255859375], [0.564453125, 0.267578125]],
+         'snapped_geometry': [[0.5141843971631206, 0.2574610244988864],
+          [0.5626477541371159, 0.26547884187082404]]}]}],
+     'artefacts': []}
+
+
+
+## Create dummy predictions
+
+Create predictions as perturbations of the gold labels (just as example). Some labels are thrown away and for some labels, two predictions are created instead of one.
+
+
+```python
+from dataclasses import replace
+from random import Random
+from typing import List, Sequence, Tuple
+
+from docile.dataset import BBox, Document, Field
+
+def fields_perturbation(rng: Random, fields: Sequence[Field], max_shift: Tuple[float, float]) -> List[Field]:
+    new_fields = []
+    for field in fields:
+        p = rng.random()
+        generate_fields = 1
+        if p < 0.2:
+            generate_fields = 0
+        elif p > 0.9:
+            generate_fields = 2
+        for _ in range(generate_fields):
+            max_shift_horizontal, max_shift_vertical = max_shift
+            left = field.bbox.left + (rng.random() * 2 - 1) * max_shift_horizontal
+            right = field.bbox.right + (rng.random() * 2 - 1) * max_shift_horizontal
+            if right < left:
+                left, right = right, left
+            top = field.bbox.top + (rng.random() * 2 - 1) * max_shift_vertical
+            bottom = field.bbox.bottom + (rng.random() * 2 - 1) * max_shift_vertical
+            if bottom < top:
+                top, bottom = bottom, top
+            new_field = replace(field, bbox=BBox(left, top, right, bottom))
+            new_fields.append(new_field)
+    return new_fields
+
+def get_max_shift_in_relative_coords(doc: Document, max_shift_px_at_200dpi: Tuple[int, int]) -> Tuple[float, float]:
+    size_at_200dpi = doc.page_image_size(page=0, dpi=200)
+    return (max_shift_px_at_200dpi[0] / size_at_200dpi[0], max_shift_px_at_200dpi[1] / size_at_200dpi[1])
+```
+
+
+```python
+rng = Random(42)
+
+max_shift = get_max_shift_in_relative_coords(sample_doc, max_shift_px_at_200dpi=(15, 5))
+kile_predictions = {sample_doc.docid: fields_perturbation(rng, sample_doc.annotation.fields, max_shift)}
+lir_predictions = {sample_doc.docid: fields_perturbation(rng, sample_doc.annotation.li_fields, max_shift)}
+```
+
+**Store predictions to json**
+
+In this format predictions are submitted to the benchmark. With the predictions stored on disk you can also run the evaluation from command line with `docile_evaluate` command.
+
+
+```python
+from docile.dataset import store_predictions
+
+store_predictions(Path("/tmp/kile-perturbations.json"), kile_predictions)
+```
+
+**Run evaluation**
+
+
+```python
+from docile.evaluation import evaluate_dataset
+
+evaluation_result = evaluate_dataset(sample_dataset, kile_predictions, lir_predictions)
+```
+
+    Run matching for documents:   0%|          | 0/1 [00:00<?, ?it/s]/root/.cache/pypoetry/virtualenvs/docile-9TtSrW0h-py3.10/lib/python3.10/site-packages/networkx/algorithms/bipartite/matching.py:569: FutureWarning:
+
+    biadjacency_matrix will return a scipy.sparse array instead of a matrix in NetworkX 3.0
+
+    Run matching for documents: 100%|██████████| 1/1 [00:00<00:00,  8.79it/s]
+
+
+
+```python
+print(evaluation_result.print_report())
+```
+
+Evaluation report for sample-dataset:dev
+========================================
+KILE
+----
+Primary metric (AP): 0.3677685950413223
+
+| fieldtype                 |    AP |    f1 |   precision |   recall |   TP |   FP |   FN |
+|---------------------------|-------|-------|-------------|----------|------|------|------|
+| **-> micro average**      | 0.368 | 0.545 |       0.545 |    0.545 |    6 |    5 |    5 |
+| account_num               | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| amount_due                | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    1 |    1 |
+| amount_paid               | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| amount_total_gross        | 1.000 | 1.000 |       1.000 |    1.000 |    1 |    0 |    0 |
+| amount_total_net          | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| amount_total_tax          | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| bank_num                  | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| bic                       | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| currency_code_amount_due  | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| customer_billing_address  | 1.000 | 1.000 |       1.000 |    1.000 |    1 |    0 |    0 |
+| customer_billing_name     | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    1 |    1 |
+| customer_delivery_address | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| customer_delivery_name    | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| customer_id               | 1.000 | 1.000 |       1.000 |    1.000 |    1 |    0 |    0 |
+| customer_order_id         | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| customer_other_address    | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| customer_other_name       | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| customer_registration_id  | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| customer_tax_id           | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| date_due                  | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    1 |    1 |
+| date_issue                | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    1 |    1 |
+| document_id               | 1.000 | 1.000 |       1.000 |    1.000 |    1 |    0 |    0 |
+| iban                      | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| order_id                  | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| payment_reference         | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    1 |    1 |
+| payment_terms             | 1.000 | 1.000 |       1.000 |    1.000 |    1 |    0 |    0 |
+| tax_detail_gross          | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| tax_detail_net            | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| tax_detail_rate           | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| tax_detail_tax            | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| vendor_address            | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| vendor_email              | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| vendor_name               | 1.000 | 1.000 |       1.000 |    1.000 |    1 |    0 |    0 |
+| vendor_order_id           | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| vendor_registration_id    | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| vendor_tax_id             | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+
+LIR
+---
+Primary metric (f1): 0.717948717948718
+
+| fieldtype                  |    AP |    f1 |   precision |   recall |   TP |   FP |   FN |
+|----------------------------|-------|-------|-------------|----------|------|------|------|
+| **-> micro average**       | 0.579 | 0.718 |       0.737 |    0.700 |   28 |   10 |   12 |
+| line_item_amount_gross     | 0.491 | 0.625 |       0.625 |    0.625 |    5 |    3 |    3 |
+| line_item_amount_net       | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_code             | 0.375 | 0.533 |       0.571 |    0.500 |    4 |    3 |    4 |
+| line_item_currency         | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_date             | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_description      | 0.732 | 0.800 |       0.857 |    0.750 |    6 |    1 |    2 |
+| line_item_discount_amount  | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_discount_rate    | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_hts_number       | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_order_id         | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_person_name      | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_position         | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_quantity         | 0.732 | 0.800 |       0.769 |    0.833 |   10 |    3 |    2 |
+| line_item_tax              | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_tax_rate         | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_unit_price_gross | 0.750 | 0.857 |       1.000 |    0.750 |    3 |    0 |    1 |
+| line_item_unit_price_net   | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_units_of_measure | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+| line_item_weight           | 0.000 | 0.000 |       0.000 |    0.000 |    0 |    0 |    0 |
+
+
+
+
+```python
+evaluation_result.get_primary_metric("kile")
+```
+
+
+
+
+    0.3677685950413223
+
+
+
+**Visualize matching**
+
+
+```python
+kile_matching = evaluation_result.task_to_docid_to_matching["kile"]
+lir_matching = evaluation_result.task_to_docid_to_matching["lir"]
+DatasetBrowser(sample_dataset, kile_matching=kile_matching, lir_matching=lir_matching)
+```
+
+![newplot (3)](https://user-images.githubusercontent.com/1220288/215839721-804dcd8e-d7de-491b-8e72-774cd7130e04.png)


### PR DESCRIPTION
While adding the tutorials I decided for last few minor changes in the `Dataset` class:
* delete `load_split()` -- it was meant for convenience (no need to repeat dataset path when loading a second dataset) but it was unnecessarily complicating the code.
* Instead add `load()` and `release()` to be able to delay loading of the dataset resources. This can be especially useful for the unlabeled dataset which usually does not fit full into memory.