### PR TITLE
Evaluate on subsets: x-shot and synthetic clusters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,9 @@ docile_evaluate \
   --dataset-path path/to/dataset[.zip] \
   --split val \
   --predictions path/to/predictions.json \
+  --evaluate-x-shot-subsets "0,1-3,4+" \  # default, show evaluation for 0-shot, few-shot and many-shot layout clusters
+  --evaluate-synthetic-subsets \  # optional, show evaluation on layout clusters with available synthetic data
+  --evaluate-fieldtypes \  # optional, show breakdown per fieldtype
   --evaluate-also-text \  # optional
   --store-evaluation-result LIR_val_eval.json  # optional, it can be loaded in the dataset browser
 ```

--- a/docile/cli/evaluate.py
+++ b/docile/cli/evaluate.py
@@ -1,10 +1,60 @@
 from pathlib import Path
-from typing import Optional
+from typing import List, Optional, Sequence
 
 import click
 
 from docile.dataset import CachingConfig, Dataset, load_predictions
-from docile.evaluation import EvaluationResult, evaluate_dataset
+from docile.evaluation import (
+    EvaluationResult,
+    NamedRange,
+    evaluate_dataset,
+    get_evaluation_subsets,
+)
+
+
+class NamedRangesParamType(click.ParamType):
+    """Parameter for list of ranges."""
+
+    name = "named_range"
+
+    def convert(self, value: str, param: click.Option, ctx: click.Context) -> List[NamedRange]:
+        """
+        Convert the input value into list of named ranges.
+
+        Parameters
+        ----------
+        value
+            List of ranges in the format 'range1,range2,...' One range can be one of 'x', 'x-y'
+            or 'x+', corresponding to ranges [x, x], [x, y] and [x, infinity).
+        param
+            Click option.
+        ctx
+            Click context.
+
+        Returns
+        -------
+        named_ranges
+            List of named ranges, i.e., tuples of string (range name) and range. Range is either
+            Tuple[int, int] or Tuple[int, None] if there is no upper bound.
+        """
+        if value == "":
+            return []
+        parsed_named_ranges: List[NamedRange] = []
+        for range_name in value.split(","):
+            size_range = range_name.split("-")
+            if range_name.isdigit():
+                parsed_named_ranges.append((range_name, (int(range_name), int(range_name))))
+            elif range_name[-1] == "+" and range_name[:-1].isdigit():
+                parsed_named_ranges.append((range_name, (int(range_name[:-1]), None)))
+            elif len(size_range) == 2 and all(x.isdigit() for x in size_range):
+                parsed_named_ranges.append((range_name, (int(size_range[0]), int(size_range[1]))))
+            else:
+                self.fail(
+                    f"Cannot parse range name {range_name}. Options are 'x', 'x-y' or 'x+'",
+                    param,
+                    ctx,
+                )
+        return parsed_named_ranges
 
 
 @click.command("Evaluate predictions on DocILE dataset")
@@ -51,6 +101,26 @@ from docile.evaluation import EvaluationResult, evaluate_dataset
     help="IoU threshold for PCC matching, can be useful for experiments",
 )
 @click.option(
+    "--evaluate-x-shot-subsets",
+    type=NamedRangesParamType(),
+    default="0,1-3,4+",
+    help=(
+        "evaluate on subsets of x-shot layout clusters. Pass empty string to turn it off. "
+        "Format: 'range1,range2,...' where range is one of 'x', 'x-y' or 'x+'."
+    ),
+    show_default=True,
+)
+@click.option(
+    "--evaluate-synthetic-subsets",
+    is_flag=True,
+    help="if used, evaluate also on subsets belonging to layout clusters with synthetic data",
+)
+@click.option(
+    "--evaluate-fieldtypes",
+    is_flag=True,
+    help="show breakdown per fiedltype",
+)
+@click.option(
     "--evaluate-also-text",
     is_flag=True,
     help="if used, also show metrics that require exact text match for predictions",
@@ -67,11 +137,15 @@ def evaluate(
     predictions: Path,
     store_evaluation_result: Optional[Path],
     iou_threshold: float,
+    evaluate_x_shot_subsets: Sequence[NamedRange],
+    evaluate_synthetic_subsets: bool,
+    evaluate_fieldtypes: bool,
     evaluate_also_text: bool,
     primary_metric_only: bool,
 ) -> None:
     dataset = Dataset(split, dataset_path, cache_images=CachingConfig.OFF)
     docid_to_predictions = load_predictions(predictions)
+    subsets = get_evaluation_subsets(dataset, evaluate_x_shot_subsets, evaluate_synthetic_subsets)
     if task == "KILE":
         evaluation_result = evaluate_dataset(
             dataset,
@@ -96,7 +170,11 @@ def evaluate(
         metric_value = evaluation_result.get_primary_metric(task.lower())
         print(metric_value)  # noqa T201
     else:
-        report = evaluation_result.print_report(include_same_text=evaluate_also_text)
+        report = evaluation_result.print_report(
+            subsets=subsets,
+            include_fieldtypes=evaluate_fieldtypes,
+            include_same_text=evaluate_also_text,
+        )
         print(report)  # noqa T201
 
 
@@ -108,16 +186,72 @@ def evaluate(
     help="path to the json file with evaluation result",
 )
 @click.option(
+    "--evaluate-x-shot-subsets",
+    type=NamedRangesParamType(),
+    default="0,1-3,4+",
+    help=(
+        "evaluate on subsets of x-shot layout clusters. Pass empty string to turn it off. "
+        "Format: 'range1,range2,...' where range is one of 'x', 'x-y' or 'x+'."
+    ),
+    show_default=True,
+)
+@click.option(
+    "--evaluate-synthetic-subsets",
+    is_flag=True,
+    help="if used, evaluate also on subsets belonging to layout clusters with synthetic data",
+)
+@click.option(
+    "--dataset-path",
+    type=click.Path(exists=True, file_okay=True, dir_okay=True, path_type=Path),
+    default=None,
+    help=(
+        "if --evaluate-x-shot-subsets (used by default) or --evaluate-synthetic-subsets are used, "
+        "you need to pass a path to the dataset"
+    ),
+)
+@click.option(
+    "--evaluate-fieldtypes",
+    is_flag=True,
+    help="show breakdown per fiedltype",
+)
+@click.option(
     "--evaluate-also-text",
     is_flag=True,
     help="if used, also show metrics that require exact text match for predictions",
 )
 def print_evaluation_report(
     evaluation_result_path: Path,
+    evaluate_x_shot_subsets: Sequence[NamedRange],
+    evaluate_synthetic_subsets: bool,
+    dataset_path: Optional[Path],
+    evaluate_fieldtypes: bool,
     evaluate_also_text: bool,
 ) -> None:
     evaluation_result = EvaluationResult.from_file(evaluation_result_path)
-    report = evaluation_result.print_report(include_same_text=evaluate_also_text)
+    subsets: List[Dataset] = []
+    if len(evaluate_x_shot_subsets) > 0 or evaluate_synthetic_subsets:
+        if dataset_path is None:
+            raise ValueError(
+                "You need to provide --dataset-path when --evaluate-x-shot-subsets (used by "
+                "default) or --evaluate-synthetic-subsets are used."
+            )
+        test_split_name: Optional[str] = None
+        for split_name in ["test", "val"]:
+            if evaluation_result.dataset_name.endswith(split_name):
+                test_split_name = split_name
+        if test_split_name is None:
+            raise ValueError(
+                f"Unknown dataset {evaluation_result.dataset_name}, cannot find x-shot subsets"
+            )
+        test = Dataset(
+            test_split_name, dataset_path, load_ocr=False, cache_images=CachingConfig.OFF
+        )
+        subsets = get_evaluation_subsets(test, evaluate_x_shot_subsets, evaluate_synthetic_subsets)
+    report = evaluation_result.print_report(
+        subsets=subsets,
+        include_fieldtypes=evaluate_fieldtypes,
+        include_same_text=evaluate_also_text,
+    )
     print(report)  # noqa T201
 
 

--- a/docile/evaluation/__init__.py
+++ b/docile/evaluation/__init__.py
@@ -1,4 +1,13 @@
 from docile.evaluation.evaluate import EvaluationResult, evaluate_dataset
+from docile.evaluation.evaluation_subsets import NamedRange, get_evaluation_subsets
 from docile.evaluation.pcc import PCC, PCCSet, get_document_pccs
 
-__all__ = ["EvaluationResult", "PCC", "PCCSet", "evaluate_dataset", "get_document_pccs"]
+__all__ = [
+    "EvaluationResult",
+    "NamedRange",
+    "PCC",
+    "PCCSet",
+    "evaluate_dataset",
+    "get_document_pccs",
+    "get_evaluation_subsets",
+]

--- a/docile/evaluation/average_precision.py
+++ b/docile/evaluation/average_precision.py
@@ -32,6 +32,9 @@ def compute_average_precision(
     -------
     Average precision metric
     """
+    if total_annotations == 0:
+        return 0.0
+
     recall_precision_pairs = [[0.0, 1.0]]  # the precision here is not used
     true_positives = 0
     observed_predictions = 0

--- a/docile/evaluation/evaluation_subsets.py
+++ b/docile/evaluation/evaluation_subsets.py
@@ -1,0 +1,134 @@
+from typing import List, Optional, Sequence, Tuple
+
+from docile.dataset import CachingConfig, Dataset
+
+NamedRange = Tuple[str, Tuple[int, Optional[int]]]
+
+
+def size_in_range(size: int, size_range: Tuple[int, Optional[int]]) -> bool:
+    """
+    Test if the cluster size lies in the given range.
+
+    Parameters
+    ----------
+    size
+        Size of the cluster.
+    size_range
+        A range [start, end], start and end is inclusive. If end is None, only start is tested.
+    """
+    return size_range[0] <= size and (size_range[1] is None or size <= size_range[1])
+
+
+def get_x_shot_subsets(
+    test: Dataset, train: Dataset, named_ranges: Sequence[NamedRange]
+) -> List[Dataset]:
+    """
+    Find subsets of test corresponding to x-shot clusters.
+
+    For each given range, find a subset of `test` documents from clusters with `x` samples in
+    `train` where `x` lies in that range.
+
+    Parameters
+    ----------
+    test
+        Dataset used for evaluation, find subsets of this dataset.
+    train
+        Dataset that contains all the documents seen during training. Then `x`-shot cluster is
+        defined as a cluster that has `x` documents in `train`. Notice that in docile, `trainval`
+        is considered to be the training set for `test` as both `train` and `val` splits can be
+        used during training (even if just for validation).
+    named_ranges
+        Sequence of tuples of names and ranges representing the cluster sizes in `train` to fall in
+        the corresponding subset.
+
+    Returns
+    -------
+    A sequence of datasets, one for each named range, that are subsets of `test` and whose clusters
+    have the correct number of documents in `train`.
+    """
+    # First parse the range names to raise an exception early if they are not valid.
+    test_cluster_ids = {doc.annotation.cluster_id for doc in test}
+    range_name_to_documents = {range_name: [] for range_name, _ in named_ranges}
+    for cluster_id in test_cluster_ids:
+        train_documents = [doc for doc in train if doc.annotation.cluster_id == cluster_id]
+        test_documents = test.get_cluster(cluster_id).documents
+        for range_name, size_range in named_ranges:
+            if size_in_range(len(train_documents), size_range):
+                range_name_to_documents[range_name].extend(test_documents)
+    return [
+        Dataset.from_documents(f"{test.split_name}-{range_name}-shot", documents)
+        for range_name, documents in range_name_to_documents.items()
+    ]
+
+
+def get_synthetic_subset(test: Dataset, synthetic_sources: Dataset) -> Optional[Dataset]:
+    """
+    Get subset of test corresponding to clusters with synthetic data available.
+
+    Returns
+    -------
+    Subset with documents in clusters that have synthetic data available. Returns None if there are
+    no such documents in `test`.
+    """
+    synthetic_cluster_ids = {doc.annotation.cluster_id for doc in synthetic_sources}
+    documents_synth = [doc for doc in test if doc.annotation.cluster_id in synthetic_cluster_ids]
+    if len(documents_synth) == 0:
+        return None
+    return Dataset.from_documents(f"{test.split_name}-synth-clusters-only", documents_synth)
+
+
+def get_evaluation_subsets(
+    test: Dataset, named_ranges: Sequence[NamedRange], synthetic: bool
+) -> List[Dataset]:
+    """
+    Find subsets corresponding to x-shot and/or synthetic clusters.
+
+    When named_ranges is given, finds x-shot clusters with respect to `trainval` for `test` and
+    w.r.t. to `train` for `val`. When synthetic is true, for each subset a variant is added that
+    includes only documents in clusters with synthetic data available.
+
+    Parameters
+    ----------
+    named_ranges
+        Sequence of tuples of names and ranges representing the cluster sizes in `train` to fall in
+        the corresponding subset.
+    synthetic
+        If true, generate subsets of documents belonging to clusters with synthetic data.
+
+    Returns
+    -------
+    List of dataset subsets, without the full `test` dataset.
+    """
+    if len(named_ranges) == 0 and not synthetic:
+        return []
+
+    # Add the full dataset to the list so that the synth version is generated below. It is removed
+    # from the output at the end.
+    subsets = [test]
+    if len(named_ranges) > 0:
+        if test.split_name == "test":
+            train_split_name = "trainval"
+        elif test.split_name == "val":
+            train_split_name = "train"
+        else:
+            raise ValueError(f"No default corresponding train dataset for {test}")
+
+        train = Dataset(
+            train_split_name, test.data_paths, load_ocr=False, cache_images=CachingConfig.OFF
+        )
+        subsets.extend(get_x_shot_subsets(test, train, named_ranges))
+
+    if synthetic:
+        new_subsets = []
+        synthetic_sources = Dataset(
+            "synthetic-sources", test.data_paths, load_ocr=False, cache_images=CachingConfig.OFF
+        )
+        for subset in subsets:
+            new_subsets.append(subset)
+            synthetic_subset = get_synthetic_subset(subset, synthetic_sources)
+            if synthetic_subset is not None:
+                new_subsets.append(synthetic_subset)
+        subsets = new_subsets
+
+    # Remove the full test set from the output
+    return subsets[1:]

--- a/docile/tools/dataset_browser.ipynb
+++ b/docile/tools/dataset_browser.ipynb
@@ -21,7 +21,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "DATASET_PATH = Path(\"/path/to/dataset/\")\n",
+    "DATASET_PATH = Path(\"/app/data/docile/\")\n",
     "dataset = Dataset(\"val\", DATASET_PATH)"
    ]
   },

--- a/tests/evaluation/test_evaluate.py
+++ b/tests/evaluation/test_evaluate.py
@@ -90,7 +90,7 @@ def test_evaluation_result_get_metrics(mock_evaluation_result: EvaluationResult)
         "f1": pytest.approx(2 / 5),
         "AP": 1 / 3,
     }
-    assert mock_evaluation_result.get_metrics("lir", fieldtype="f05", docid="b") == {
+    assert mock_evaluation_result.get_metrics("lir", fieldtype="f05", docids=["b"]) == {
         "TP": 1,
         "FP": 2,
         "FN": 0,
@@ -122,6 +122,9 @@ Primary metric (f1): 0.5
 | fieldtype            |   AP |   f1 |   precision |   recall |   TP |   FP |   FN |
 |----------------------|------|------|-------------|----------|------|------|------|
 | **-> micro average** | 0.47 | 0.50 |        0.50 |     0.50 |    2 |    2 |    2 |
+
+Notes:
+* For AP all predictions are used. For f1, precision, recall, TP, FP and FN predictions explicitly marked with flag `use_only_for_ap=True` are excluded.
 """
     )
 


### PR DESCRIPTION
Default is now to print without showing fieldtypes and with showing these subsets: 0-shot, 1-3-shot and 4+-shot.