### PR TITLE
Dataset: fix from_documents for zipped dataset

### DIFF
--- a/docile/dataset/dataset.py
+++ b/docile/dataset/dataset.py
@@ -245,6 +245,7 @@ class Dataset:
             # Do not load annotations and OCR since it might be already loaded once in `documents`.
             load_annotations=False,
             load_ocr=False,
+            cache_images=CachingConfig.OFF,
             docids=[doc.docid for doc in documents],
         )
         dataset._set_documents(documents)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "docile"
-version = "0.2.0"
+version = "0.2.1"
 description = "Tools to work with the DocILE dataset and benchmark"
 authors = [
     "Stepan Simsa <stepan.simsa@rossum.ai>",


### PR DESCRIPTION
The Dataset initialization (before the `_set_documents` call) was broken for zipped dataset because image caching cannot be used for them. The option is anyway ignored as it's stored on document level and documents are replaced with the `_set_documents` call.