### PR TITLE
Publish docile under new name and pin pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.3.0
+    rev: v4.4.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -21,32 +21,32 @@ repos:
       - id: flake8
         args: [--config, .flake8, --benchmark]
         additional_dependencies: [
-          flake8-bugbear,
-          flake8-logging-format,
-          flake8-absolute-import,
-          flake8-breakpoint,
-          flake8-colors,
-          flake8-comprehensions,
-          flake8-docstrings,
-          flake8-eradicate,
-          flake8-plugin-utils,
-          flake8-print,
-          flake8-polyfill,
-          flake8-unused-arguments,
-          flake8-use-fstring
+          flake8-bugbear==23.2.13,
+          flake8-logging-format==0.9.0,
+          flake8-absolute-import==1.0.0.1,
+          flake8-breakpoint==1.1.0,
+          flake8-colors==0.1.9,
+          flake8-comprehensions==3.10.1,
+          flake8-docstrings==1.7.0,
+          flake8-eradicate==1.4.0,
+          flake8-plugin-utils==1.3.2,
+          flake8-print==5.0.0,
+          flake8-polyfill==1.0.2,
+          flake8-unused-arguments==0.0.13,
+          flake8-use-fstring==1.4
         ]
   - repo: https://github.com/PyCQA/pydocstyle
-    rev: 6.1.1
+    rev: 6.3.0
     hooks:
       - id: pydocstyle
         additional_dependencies:
-          - toml
+          - tomli==2.0.1
   - repo: https://github.com/codespell-project/codespell
     rev: v2.2.2
     hooks:
       - id: codespell
         additional_dependencies:
-          - tomli
+          - tomli==2.0.1
 
   - repo: https://github.com/PyCQA/isort
     rev: 5.12.0
@@ -54,27 +54,27 @@ repos:
       - id: isort
         args: [--settings-path=pyproject.toml, --filter-files]
   - repo: https://github.com/python/black
-    rev: 22.10.0
+    rev: 23.1.0
     hooks:
       - id: black
         # Configuration needs to be explicit because of https://github.com/psf/black/issues/2863
         args: [--config, pyproject.toml]
   - repo: https://github.com/pre-commit/mirrors-mypy
-    rev: v0.982
+    rev: v1.0.1
     hooks:
       - id: mypy
         name: mypy
         additional_dependencies: [
-          importlib_resources,
-          more_itertools,
-          numpy,
-          pandas-stubs,
-          pytest-mock,
-          pytest-stub,
-          types-dataclasses,
-          types-Pillow,
-          types-setuptools,
-          types-tabulate
+          importlib_resources==5.12.0,
+          more_itertools==9.1.0,
+          numpy==1.24.2,
+          pandas-stubs==1.5.3.230227,
+          pytest-mock==3.10.0,
+          pytest-stub==1.1.0,
+          types-dataclasses==0.6.6,
+          types-Pillow==9.4.0.17,
+          types-setuptools==67.4.0.3,
+          types-tabulate==0.9.0.1
         ]
         args: []
         language: python

--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ You can also work with the zipped datasets when you turn off image caching (chec
 ## Installation
 
 ### Option 1: Install as a library
-To install just the library, download the wheel from the [latest release on github](https://github.com/rossumai/docile/releases) and run:
+Install the library with:
 ```shell
-pip install docile-0.1.0-py3-none-any.whl
+pip install docile-benchmark
 ```
 
 To convert pdfs into images, the library uses https://github.com/Belval/pdf2image. On linux you might need to install:
@@ -55,8 +55,8 @@ brew install poppler
 
 Now you have all dependencies to work with the dataset annotations, pdfs, pre-comptued OCR and to run the evaluation. You can install extra dependencies by running the following (although using one of the provided dockerfiles, as explained below, might be easier in this case):
 ```shell
-pip install "docile-0.1.0-py3-none-any.whl[interactive]"
-pip install "docile-0.1.0-py3-none-any.whl[ocr]"
+pip install "docile-benchmark[interactive]"
+pip install "docile-benchmark[ocr]"
 ```
 
 The first line installs additional dependencies allowing you to use the interactive dataset browser in [docile/tools/dataset_browser.py](docile/tools/dataset_browser.py) and the [tutorials](tutorials/). The second line let's you rerun the OCR predictions from scratch (e.g., if you'd like to run it with different parameters) but to make it work, you might need additional dependencies on your system. Check https://github.com/mindee/doctr for the installation instructions (for pytorch).

--- a/docile/dataset/field.py
+++ b/docile/dataset/field.py
@@ -41,7 +41,7 @@ class Field:
         expected_keys = {f.name for f in dataclasses.fields(cls)}
         for k in list(dct_copy.keys()):
             if k not in expected_keys:
-                warnings.warn(f"Ignoring unexpected key {k}")
+                warnings.warn(f"Ignoring unexpected key {k}", stacklevel=1)
                 dct_copy.pop(k)
 
         return cls(bbox=bbox, **dct_copy)

--- a/docile/tools/dataset_browser.py
+++ b/docile/tools/dataset_browser.py
@@ -1,7 +1,7 @@
 import enum
 import warnings
 from dataclasses import dataclass
-from typing import List, Tuple
+from typing import List, Mapping, Optional, Tuple
 
 import ipywidgets as widgets
 import plotly.graph_objects as go
@@ -88,10 +88,10 @@ class DatasetBrowser:
         dataset: Dataset,
         doc_i: int = 0,
         page_i: int = 0,
-        kile_matching: dict = None,
-        lir_matching: dict = None,
-        kile_predictions: dict = None,
-        lir_predictions: dict = None,
+        kile_matching: Optional[Mapping] = None,
+        lir_matching: Optional[Mapping] = None,
+        kile_predictions: Optional[Mapping] = None,
+        lir_predictions: Optional[Mapping] = None,
         display_grid: bool = False,
     ) -> None:
         """
@@ -120,11 +120,13 @@ class DatasetBrowser:
         """
         if kile_matching is not None and kile_predictions is not None:
             warnings.warn(
-                "Displaying predictions from provided kile_matching, kile_predictions are ignored."
+                "Displaying predictions from provided kile_matching, kile_predictions are ignored.",
+                stacklevel=1,
             )
         if lir_matching is not None and lir_predictions is not None:
             warnings.warn(
-                "Displaying predictions from provided lir_matching, lir_predictions are ignored."
+                "Displaying predictions from provided lir_matching, lir_predictions are ignored.",
+                stacklevel=1,
             )
 
         self.dataset = dataset

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
-name = "docile"
-version = "0.2.1"
+name = "docile-benchmark"
+version = "0.2.2"
 description = "Tools to work with the DocILE dataset and benchmark"
 authors = [
     "Stepan Simsa <stepan.simsa@rossum.ai>",


### PR DESCRIPTION
There is a different project on pypi called docile so we have to use a different name: https://pypi.org/project/docile-benchmark/. This PR also fixes some problems with pre-commit caused by unpinned additional dependencies.