### PR TITLE
Baselines, add table with results

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,8 @@ Explanation of the individual fields of the predictions:
 
 You can use [Field class](docile/dataset/field.py) to work with the predictions in code, in which case you can store them in a json file in the required format by using the `docile.dataset.store_predictions` function. You can also use the [BBox class](docile/dataset/bbox.py) to easily convert between relative and absolute coordinates (relative coordinates are used everywhere by default).
 
+Use [docile/tools/print_results.py](docile/tools/print_results.py) to display results of your predictions formatted in a table (choosing from table styles like github, latex or csv).
+
 ## Tasks and evaluation metrics
 
 The DocILE benchmark comes with two tracks, Key Information Localization and Extraction (KILE) and Line Item Recognition (LIR), as described in the [dataset and benchmark paper](#dataset-and-benchmark-paper). In both tracks, the goal is to localize key information of pre-defined categories, i.e., for each document, detect fields with their `fieldtype`, location (`page` and `bbox`) and optionally `text`. For LIR, fields have to be additionally grouped into line items. A Line Item (LI) is a tuple of fields (e.g., description, quantity, and price) describing a single object instance to be extracted, e.g., a row in a table.

--- a/baselines/README.md
+++ b/baselines/README.md
@@ -4,8 +4,6 @@ The DocILE benchmark comes with several baselines to help you get started and to
 
 ## Download checkpoints and predictions
 
-> :warning: The predictions on the validation set are not yet included, they will be added in the next few days.
-
 Checkpoints of various trained models are provided with predictions on the validation set. You can download them with the same [download script](../download_dataset.sh) that is provided for downloading the dataset in the root of this repository.
 
 First you need to obtain a secret token by following the instructions at https://docile.rossum.ai/. Then run this from the root of this repository:
@@ -21,19 +19,48 @@ The baselines available for download are below and contain the PyTorch checkpoin
 * `baselines-roberta-base`: RoBERTa model trained from the `roberta-base` Hugging Face dataset.
 * `baselines-roberta-ours`: RoBERTa model trained from our pretrained model (`baselines-roberta-pretraining`)
 * `baselines-layoutlmv3-ours`: LayoutLMv3 model trained from our pretrained model (`baselines-layoutlmv3-pretraining`)
-* `baselines-detr`: DETR model trained to detect tables and Line Items for the LIR task.
 * `baselines-roberta-pretraining`: Unsupervised pre-training for RoBERTa on the `unlabeled` set.
 * `baselines-layoutlmv3-pretraining`: Unsupervised pre-training for LayoutLMv3 on the `unlabeled` set.
+* `baselines-detr`: DETR model trained to detect tables and Line Items for the LIR task. Provided predictions on the validation set include table and LI predictions and also predictions of `roberta-base` model that uses these DETR predictions during inference.
+* `baselines-roberta-base-with-synthetic-pretraining`, `baselines-roberta-ours-with-synthetic-pretraining`, `baselines-layoutlmv3-ours-with-synthetic-pretraining`: Versions of the RoBERTa and LayoutLMv3 models that were first pretrained on the synthetic data before being trained on the annotated data. All three baselines come with two checkpoints, one after synthetic pretraining and one after the final training, and predictions on validation set after the final training.
 
 ## Code to run trainings and inference
 
-We provide code to reproduce all results that can be found in the [paper](../README.md#dataset-and-benchmark-paper). Some small errors were found and fixed in the training and inference scripts that influence the numbers presented in the paper v1 version. These should be fixed in an updated version that we aim to make available on arXiv in April 2023.
+We provide code to reproduce all results that can be found in the [paper](../README.md#dataset-and-benchmark-paper). Some small errors were found and fixed in the training and inference scripts that influence the numbers presented in the paper v1 version. These should be fixed in an updated version that we aim to make available on arXiv in April 2023. You can see the updated comparison of the provided baselines in the following section.
 
 The code is structured into three subfolders:
 * [NER](NER/) contains most of the baselines code, including training code for RoBERTa, LayoutLMv3 and RoBERTa pretraining, and the inference code.
 * [layoutlmv3_pretraing](layoutlmv3_pretrain/) [coming soon] contains code for LayoutLMv3 pretraining
 * [table-transformer](table-transformer/) [coming soon] contains code for DETR used for table and Line Item detection.
 
-## Results on the validation set
+## Results of the provided baselines
 
-Coming soon, results of the baselines on the validation set will appear here.
+While results on the test set better compare which models work better, results on the validation set can be used to easily compare your models against the baselines, since annotations for test set are not publicly available and the only way to run the evaluations on the test set is to make a submission to the benchmark on the [RRC website](https://rrc.cvc.uab.es/?ch=26).
+
+### KILE
+
+The main benchmark metric for KILE is `AP`, the best results on AP are bold in the table.
+
+| model                                      | <ins>val-AP</ins>   |   val-F1 |   val-precision |   val-recall | <ins>test-AP</ins>   |   test-F1 |   test-precision |   test-recall |
+|--------------------------------------------|---------------------|----------|-----------------|--------------|----------------------|-----------|------------------|---------------|
+| roberta_base                               | 0.531               |    0.656 |           0.645 |        0.668 | 0.515                |     0.634 |            0.623 |         0.645 |
+| roberta_ours                               | 0.528               |    0.661 |           0.647 |        0.675 | 0.503                |     0.634 |            0.617 |         0.651 |
+| layoutlmv3_ours                            | 0.453               |    0.608 |           0.611 |        0.605 | 0.451                |     0.587 |            0.588 |         0.585 |
+| roberta_base_with_synthetic_pretraining    | 0.554               |    0.680 |           0.676 |        0.683 | 0.537                |     0.659 |            0.653 |         0.665 |
+| roberta_ours_with_synthetic_pretraining    | **0.557**           |    0.683 |           0.682 |        0.683 | **0.541**            |     0.656 |            0.655 |         0.657 |
+| layoutlmv3_ours_with_synthetic_pretraining | 0.507               |    0.656 |           0.662 |        0.651 | 0.493                |     0.641 |            0.646 |         0.636 |
+
+### LIR
+
+The main benchmark metric for LIR is `F1`, the best results on F1 are bold in the table.
+
+| model                                      |   val-AP | <ins>val-F1</ins>   |   val-precision |   val-recall |   test-AP | <ins>test-F1</ins>   |   test-precision |   test-recall |
+|--------------------------------------------|----------|---------------------|-----------------|--------------|-----------|----------------------|------------------|---------------|
+| roberta_base                               |    0.542 | 0.675               |           0.695 |        0.656 |     0.548 | 0.669                |            0.679 |         0.659 |
+| roberta_ours                               |    0.533 | 0.657               |           0.672 |        0.643 |     0.571 | **0.674**            |            0.685 |         0.663 |
+| layoutlmv3_ours                            |    0.549 | 0.665               |           0.692 |        0.639 |     0.549 | 0.667                |            0.683 |         0.652 |
+| roberta_base_with_synthetic_pretraining    |    0.567 | 0.688               |           0.706 |        0.670 |     0.556 | 0.665                |            0.684 |         0.646 |
+| roberta_ours_with_synthetic_pretraining    |    0.553 | **0.689**           |           0.722 |        0.659 |     0.551 | 0.671                |            0.700 |         0.644 |
+| layoutlmv3_ours_with_synthetic_pretraining |    0.553 | 0.656               |           0.679 |        0.635 |     0.555 | 0.661                |            0.682 |         0.640 |
+| roberta_base_detr_table                    |    0.519 | 0.660               |           0.700 |        0.624 |     0.526 | 0.652                |            0.675 |         0.631 |
+| roberta_base_detr_tableLI                  |    0.408 | 0.599               |           0.652 |        0.554 |     0.402 | 0.584                |            0.623 |         0.549 |

--- a/docile/tools/print_results.py
+++ b/docile/tools/print_results.py
@@ -1,0 +1,119 @@
+import argparse
+from pathlib import Path
+from typing import List, Mapping, Sequence, Tuple, Union
+
+from tabulate import tabulate
+
+from docile.evaluation import EvaluationResult
+from docile.evaluation.evaluate import TASK_TO_PRIMARY_METRIC_NAME
+
+
+def _highlight_best_numbers(
+    main_metric: str,
+    headers: Sequence[str],
+    rows: Sequence[Sequence[Union[str, int]]],
+    tablefmt: str,
+    floatfmt: str,
+) -> Tuple[List[str], List[List[Union[str, int]]]]:
+    """Return updated headers and rows, highlighting the main metric with its best numbers."""
+    if tablefmt != "github":
+        raise NotImplementedError("Highlight only works for github style tables")
+    main_metric_col_is = [i for i, h in enumerate(headers) if h.endswith(main_metric)]
+    headers_task = list(headers)
+    rows_task = [list(row) for row in rows]
+    for col_i in main_metric_col_is:
+        headers_task[col_i] = f"<ins>{headers_task[col_i]}</ins>"  # underline in github
+        max_i = max(range(len(rows_task)), key=lambda i: rows_task[i][col_i])
+        for i in range(len(rows_task)):
+            rows_task[i][col_i] = f"{rows_task[i][col_i]:{floatfmt}}"
+        rows_task[max_i][col_i] = f"**{rows_task[max_i][col_i]}**"
+    return headers_task, rows_task
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "--predictions-dir",
+        type=Path,
+        help=(
+            "Path to directory with evaluation results of your models. It should contain a "
+            "subdirectory for each model with {split}_results_KILE.json and/or "
+            "{split}_results_LIR.json files."
+        ),
+    )
+    parser.add_argument(
+        "--split",
+        type=str,
+        default="val",
+        help='you can pass multiple splits separated by commas, e.g., --split="val,test"',
+    )
+    parser.add_argument(
+        "--tablefmt",
+        type=str,
+        default="github",
+        help="table format such as 'github' or 'latex', see `tabulate` package for more options",
+    )
+    parser.add_argument("--floatfmt", type=str, default=".3f")
+    parser.add_argument(
+        "--models",
+        type=str,
+        default="",
+        help="models to include in the table (in the given order), separated by commas",
+    )
+    parser.add_argument(
+        "--show-counts",
+        action="store_true",
+        help="show counts of True Positive and False Positive/Negative predictions",
+    )
+    parser.add_argument(
+        "--highlight-best-numbers",
+        action="store_true",
+        help=(
+            "highlight the best numbers for the main metric, only implemented for "
+            "--table-format=github"
+        ),
+    )
+    args = parser.parse_args()
+
+    splits = args.split.split(",")
+
+    metric_names = ["AP", "f1", "precision", "recall"]
+    if args.show_counts:
+        metric_names.extend(["TP", "FP", "FN"])
+    headers = ["model"]
+    for split in splits:
+        prefix = f"{split}-" if len(splits) > 1 else ""
+        headers.extend([f"{prefix}{m}" for m in metric_names])
+
+    rows = {"KILE": [], "LIR": []}
+    models_paths = list(args.predictions_dir.iterdir())
+    if args.models != "":
+        models_paths = [args.predictions_dir / m for m in args.models.split(",")]
+    for model_dir in models_paths:
+        for task in ["KILE", "LIR"]:
+            row = [model_dir.name]
+            for split in splits:
+                results_path = model_dir / f"{split}_results_{task}.json"
+                metrics: Mapping[str, Union[str, float]] = {m: "-" for m in metric_names}
+                if results_path.exists():
+                    eval_result = EvaluationResult.from_file(results_path)
+                    metrics = eval_result.get_metrics(task.lower())
+                row.extend([metrics[m] for m in metric_names])
+            rows[task].append(row)
+
+    report = []
+    for task in ["KILE", "LIR"]:
+        headers_task, rows_task = headers, rows[task]
+        if args.highlight_best_numbers:
+            main_metric = TASK_TO_PRIMARY_METRIC_NAME[task.lower()]
+            headers_task, rows_task = _highlight_best_numbers(
+                main_metric, headers_task, rows_task, args.tablefmt, args.floatfmt
+            )
+        report.append(task)
+        report.append("=" * len(task))
+        report.append("")
+        table = tabulate(rows_task, headers_task, tablefmt=args.tablefmt, floatfmt=args.floatfmt)
+        report.extend(table.splitlines())
+        report.append("")
+
+    print("\n".join(report))  # noqa T201

--- a/download_dataset.sh
+++ b/download_dataset.sh
@@ -109,9 +109,12 @@ elif [[ "$dataset" == "baselines" ]]; then
   download_and_unzip "$token" "$targetdir" "$unzip" "baselines-roberta-base"
   download_and_unzip "$token" "$targetdir" "$unzip" "baselines-roberta-ours"
   download_and_unzip "$token" "$targetdir" "$unzip" "baselines-layoutlmv3-ours"
-  download_and_unzip "$token" "$targetdir" "$unzip" "baselines-detr"
   download_and_unzip "$token" "$targetdir" "$unzip" "baselines-roberta-pretraining"
   download_and_unzip "$token" "$targetdir" "$unzip" "baselines-layoutlmv3-pretraining"
+  download_and_unzip "$token" "$targetdir" "$unzip" "baselines-detr"
+  download_and_unzip "$token" "$targetdir" "$unzip" "baselines-roberta-base-with-synthetic-pretraining"
+  download_and_unzip "$token" "$targetdir" "$unzip" "baselines-roberta-ours-with-synthetic-pretraining"
+  download_and_unzip "$token" "$targetdir" "$unzip" "baselines-layoutlmv3-ours-with-synthetic-pretraining"
 else
   download_and_unzip "$token" "$targetdir" "$unzip" "$dataset"
 fi


### PR DESCRIPTION
Provide more baselines for download (baselines with synthetic pretraining) and predictions on validation set. Add table with results of the provided baselines on validation and test sets. Also add a script that can print tables like this (to easily transfer results to spreadsheets, markdown or latex).