### PR TITLE
Baselines, fix LayoutLMv3 synthetic pretraining, process dataset chunks

### DIFF
--- a/baselines/NER/docile_train_NER_multilabel.py
+++ b/baselines/NER/docile_train_NER_multilabel.py
@@ -1,6 +1,7 @@
 import argparse
 import dataclasses
 import json
+import math
 import os
 from bisect import bisect_left, bisect_right
 from datetime import datetime
@@ -11,6 +12,7 @@ import torch
 import torchmetrics
 from data_collator import MyMLDataCollatorForTokenClassification
 from datasets import Dataset as ArrowDataset
+from datasets import concatenate_datasets
 from helpers import FieldWithGroups, show_summary
 from my_roberta_multilabel import MyXLMRobertaMLForTokenClassification
 from tqdm import tqdm
@@ -112,7 +114,7 @@ class NERDataMaker:
         self.processed_tables = []
 
         temp_processed_tables = []
-        for page_data in data:
+        for page_data in tqdm(data, desc="Processing tables 1/2"):
             tokens_with_entities = tag_fields_with_entities(page_data, self.unique_entities)
             if tokens_with_entities:
                 if not have_unique_entities:
@@ -124,7 +126,7 @@ class NERDataMaker:
         if not have_unique_entities:
             self.unique_entities.sort(key=lambda ent: ent if ent != "O" else "")
 
-        for tokens_with_entities in temp_processed_tables:
+        for tokens_with_entities in tqdm(temp_processed_tables, desc="Processing tables 2/2"):
             self.processed_tables.append(
                 [
                     # (t, self.unique_entities.index(ent), info)
@@ -365,12 +367,11 @@ def get_sorted_field_candidates(original_fields):
     return fields, clusters
 
 
-def get_data_from_docile(split, docile_path, overlap_thr=0.5):
+def get_data_from_docile(dataset, overlap_thr=0.5):
     data = []
     metadata = []
-    dataset = Dataset(split, docile_path)
 
-    for document in tqdm(dataset):
+    for document in tqdm(dataset, desc=f"Generating data from {dataset}"):
         doc_id = document.docid
         # page_to_table_grids = document.annotation.content["metadata"]["page_to_table_grids"]
 
@@ -558,6 +559,99 @@ def store_data(dest: Path, data):
         json.dump(out, json_file)
 
 
+def _arrow_dataset_path(arrow_format_path, docile_dataset):
+    return arrow_format_path / docile_dataset.split_name
+
+
+def prepare_hf_dataset(
+    docile_dataset,
+    tokenizer,
+    overlap_thr,
+    arrow_format_path,
+    preprocessed_dataset_path,
+    chunk_size=100000,
+):
+    if len(docile_dataset) > chunk_size:
+        if not arrow_format_path:
+            raise NotImplementedError(
+                f"You need to set --arrow-format-path because {docile_dataset} has more than 10000 documents"
+            )
+        num_chunks = math.ceil(len(docile_dataset) / chunk_size)
+        dataset_chunks = []
+        for chunk in range(num_chunks):
+            chunk_dataset = docile_dataset[chunk * chunk_size : (chunk + 1) * chunk_size]
+            chunk_dataset.split_name = f"{docile_dataset.split_name}_chunk_{chunk}_of_{num_chunks}"
+            # make sure the chunk is stored to disk
+            prepare_hf_dataset(
+                chunk_dataset,
+                tokenizer,
+                overlap_thr,
+                arrow_format_path,
+                preprocessed_dataset_path,
+                chunk_size,
+            )
+            # load it from disk
+            dataset_chunk = ArrowDataset.load_from_disk(
+                _arrow_dataset_path(arrow_format_path, chunk_dataset)
+            )
+            dataset_chunks.append(dataset_chunk)
+        return concatenate_datasets(dataset_chunks)
+
+    if arrow_format_path:
+        try:
+            load_path = _arrow_dataset_path(arrow_format_path, docile_dataset)
+            print(f"Loading dataset in arrow format from path {load_path}")
+            return ArrowDataset.load_from_disk(load_path)
+        except Exception:
+            print(f"Could not load {docile_dataset.split_name} in arrow format, regenerating.")
+
+    if preprocessed_dataset_path:
+        dataset_name = docile_dataset.data_paths.name
+        preprocessed_path = preprocessed_dataset_path / dataset_name
+        print(
+            f"Loading preprocessed {docile_dataset.split_name} data from path {preprocessed_path}"
+        )
+        try:
+            data = load_data(
+                preprocessed_path / f"{docile_dataset.split_name}_multilabel_preprocessed.json"
+            )
+            metadata = load_metadata(
+                preprocessed_path / f"{docile_dataset.split_name}_multilabel_metadata.json"
+            )
+        except Exception:
+            print(f"Could not load preprocessed {docile_dataset.split_name}, regenerating.")
+            data, metadata = get_data_from_docile(docile_dataset, overlap_thr=overlap_thr)
+            print(
+                f"Storing preprocessed {docile_dataset.split_name} data to {preprocessed_dataset_path}"
+            )
+            os.makedirs(preprocessed_dataset_path / dataset_name, exist_ok=True)
+            store_data(
+                preprocessed_path / f"{docile_dataset.split_name}_multilabel_preprocessed.json",
+                data,
+            )
+            store_metadata(
+                preprocessed_path / f"{docile_dataset.split_name}_multilabel_metadata.json",
+                metadata,
+            )
+    else:
+        data, metadata = get_data_from_docile(docile_dataset, overlap_thr=overlap_thr)
+
+    data_maker = NERDataMaker(data, metadata, unique_entities=unique_entities, use_BIO_format=True)
+    print("Converting dataset to HuggingFace format")
+    dataset = data_maker.as_hf_dataset(
+        tokenizer=tokenizer, stride=args.stride, tag_everything=args.tag_everything
+    )
+    if arrow_format_path:
+        store_path = _arrow_dataset_path(arrow_format_path, docile_dataset)
+        print(
+            f"Storing HuggingFace Dataset for {docile_dataset.split_name} in arrow format to: {store_path}"
+        )
+        dataset.save_to_disk(store_path)
+        print(f"HuggingFace Dataset for {docile_dataset.split_name} in arrow format stored")
+
+    return dataset
+
+
 if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
@@ -570,18 +664,6 @@ if __name__ == "__main__":
         type=str,
         default="train",
         # default="synthetic",
-    )
-    parser.add_argument(
-        "--hgdataset_dir_train",
-        type=Path,
-        default=None,
-        help="Folder with json files for NER task.",
-    )
-    parser.add_argument(
-        "--hgdataset_dir_val",
-        type=Path,
-        default=None,
-        help="Folder with json files for NER task.",
     )
     parser.add_argument(
         "--overlap_thr",
@@ -684,23 +766,12 @@ if __name__ == "__main__":
         default=2500,
     )
     parser.add_argument(
-        "--arrow_format",
-        action="store_true",
-        help="",
-    )
-    parser.add_argument("--save_datasets_in_arrow_format", type=Path, default=None)
-    parser.add_argument(
-        "--dataset_name",
-        type=str,
-        default="docile221221-0",
-    )
-    parser.add_argument(
-        "--load_from_preprocessed",
+        "--arrow_format_path",
         type=Path,
         default=None,
     )
     parser.add_argument(
-        "--store_preprocessed",
+        "--preprocessed_dataset_path",
         type=Path,
         default=None,
     )
@@ -784,105 +855,24 @@ if __name__ == "__main__":
     id2label = dict(enumerate(unique_entities))
     label2id = {v: k for k, v in id2label.items()}
 
-    if args.arrow_format:
-        train_dataset = ArrowDataset.load_from_disk(args.hgdataset_dir_train)
-        val_dataset = ArrowDataset.load_from_disk(args.hgdataset_dir_val)
-    else:
-        # Prepare val dataset
-        if args.load_from_preprocessed:
-            try:
-                val_data = load_data(
-                    args.load_from_preprocessed
-                    / args.dataset_name
-                    / "val_multilabel_preprocessed.json"
-                )
-                val_metadata = load_metadata(
-                    args.load_from_preprocessed
-                    / args.dataset_name
-                    / "val_multilabel_metadata.json"
-                )
-            except Exception:
-                print(
-                    f"WARNING: could not load val_data from {args.load_from_preprocessed}. Need to generate them again..."
-                )
-                val_data, val_metadata = get_data_from_docile(
-                    "val", args.docile_path, overlap_thr=args.overlap_thr
-                )
-        else:
-            val_data, val_metadata = get_data_from_docile(
-                "val", args.docile_path, overlap_thr=args.overlap_thr
-            )
-        if args.store_preprocessed:
-            os.makedirs(args.store_preprocessed / args.dataset_name, exist_ok=True)
-            store_data(
-                args.store_preprocessed / args.dataset_name / "val_multilabel_preprocessed.json",
-                val_data,
-            )
-            store_metadata(
-                args.store_preprocessed / args.dataset_name / "val_multilabel_metadata.json",
-                val_metadata,
-            )
-
-        val_dm = NERDataMaker(
-            val_data, val_metadata, unique_entities=unique_entities, use_BIO_format=True
-        )
-        val_dataset = val_dm.as_hf_dataset(
-            tokenizer=tokenizer, stride=args.stride, tag_everything=args.tag_everything
-        )
-        if args.save_datasets_in_arrow_format:
-            val_dataset.save_to_disk(
-                args.save_datasets_in_arrow_format / f"NER_{args.hgdataset_dir_val.name}"
-            )
-
-        # Prepare train dataset
-        if args.load_from_preprocessed:
-            try:
-                train_data = load_data(
-                    args.load_from_preprocessed
-                    / args.dataset_name
-                    / f"{args.split}_multilabel_preprocessed.json"
-                )
-                train_metadata = load_metadata(
-                    args.load_from_preprocessed
-                    / args.dataset_name
-                    / f"{args.split}_multilabel_metadata.json"
-                )
-            except Exception:
-                print(
-                    f"WARNING: could not load train_data from {args.load_from_preprocessed}. Need to generate them again..."
-                )
-                train_data, train_metadata = get_data_from_docile(
-                    args.split, args.docile_path, overlap_thr=args.overlap_thr
-                )
-        else:
-            train_data, train_metadata = get_data_from_docile(
-                args.split, args.docile_path, overlap_thr=args.overlap_thr
-            )
-        if args.store_preprocessed:
-            os.makedirs(args.store_preprocessed / args.dataset_name, exist_ok=True)
-            store_data(
-                args.store_preprocessed
-                / args.dataset_name
-                / f"{args.split}_multilabel_preprocessed.json",
-                train_data,
-            )
-            store_metadata(
-                args.store_preprocessed
-                / args.dataset_name
-                / f"{args.split}_multilabel_metadata.json",
-                train_metadata,
-            )
-
-        train_dm = NERDataMaker(
-            train_data, train_metadata, unique_entities=unique_entities, use_BIO_format=True
-        )
-        train_dataset = train_dm.as_hf_dataset(
-            tokenizer=tokenizer, stride=args.stride, tag_everything=args.tag_everything
-        )
-        if args.save_datasets_in_arrow_format:
-            train_dataset.save_to_disk(
-                args.save_datasets_in_arrow_format / f"NER_{args.hgdataset_dir_train.name}"
-            )
+    val_docile_dataset = Dataset("val", args.docile_path, load_annotations=False, load_ocr=False)
+    val_dataset = prepare_hf_dataset(
+        val_docile_dataset,
+        tokenizer,
+        args.overlap_thr,
+        args.arrow_format_path,
+        args.preprocessed_dataset_path,
+    )
+    train_docile_dataset = Dataset(
+        args.split, args.docile_path, load_annotations=False, load_ocr=False
+    )
+    train_dataset = prepare_hf_dataset(
+        train_docile_dataset,
+        tokenizer,
+        args.overlap_thr,
+        args.arrow_format_path,
+        args.preprocessed_dataset_path,
+    )
 
     if args.use_roberta:
         config = RobertaConfig.from_pretrained(args.model_name)
@@ -1037,14 +1027,6 @@ if __name__ == "__main__":
         trainer.eval_dataset = train_dataset
         metrics = trainer.evaluate()
         trainer.log_metrics("train-eval", metrics)
-
-    if args.save_datasets_in_arrow_format:
-        print(
-            f"HuggingFace Dataset TRN stored to: {args.save_datasets_in_arrow_format / f'NER_{args.hgdataset_dir_train.name}'}"
-        )
-        print(
-            f"HuggingFace Dataset VAL stored to: {args.save_datasets_in_arrow_format / f'NER_{args.hgdataset_dir_test.name}'}"
-        )
 
     print(f"Tensorboard logs: {os.path.join(args.output_dir, 'runs')}")
     print(f"Best model saved to {best_model_path}")

--- a/baselines/NER/run_training.sh
+++ b/baselines/NER/run_training.sh
@@ -26,11 +26,13 @@ NER_SCRIPTS_DIR="/app/baselines/NER"
 CHECKPOINTS_DIR="/app/data/baselines/checkpoints"
 
 # Common parameters for all trainings with exception of roberta_pretraining
-DATA="--dataset_name docile --docile_path /app/data/docile/"
-PREPROCESSED_DATASET_DIR="/app/data/baselines/preprocessed_dataset"
-USE_PREPROCESSED="--load_from_preprocessed ${PREPROCESSED_DATASET_DIR} --store_preprocessed ${PREPROCESSED_DATASET_DIR}"
+DATA="--docile_path /app/data/docile/"
+USE_PREPROCESSED="--preprocessed_dataset_path /app/data/baselines/preprocessed_dataset"
 OTHER_COMMON_PARAMS="--save_total_limit 3 --weight_decay 0.001 --lr 2e-5 --dataloader_num_workers 8 --use_BIO_format --tag_everything --report_all_metrics --stride 0"
 COMMON_PARAMS="${DATA} ${USE_PREPROCESSED} ${OTHER_COMMON_PARAMS}"
+
+# Used for synthetic pretraining of LayoutLMv3
+USE_ARROW="--arrow_format_path /app/data/baselines/preprocessed_dataset_arrow_format"
 
 function run_training() {
   cmd=$1
@@ -129,7 +131,7 @@ fi
 
 single_run="layoutlmv3_ours_synthetic_pretraining"  # 30 epochs on synthetic data only
 if [[ " ${run} " =~ " ${single_run} " ]]; then
-  data_params="--split synthetic"
+  data_params="--split synthetic ${USE_ARROW}"
   train_params="--train_bs 16 --test_bs 16 --num_epochs 30 --gradient_accumulation_steps 1 --warmup_ratio 0"
   model="--model_name microsoft/layoutlmv3-base --pretrained_weights ${CHECKPOINTS_DIR}/layoutlmv3_pretraining.ckpt"
   all_params="${COMMON_PARAMS} ${data_params} ${train_params} ${model}"

--- a/poetry.lock
+++ b/poetry.lock
@@ -924,19 +924,19 @@ files = [
 
 [[package]]
 name = "datasets"
-version = "2.10.1"
+version = "2.9.0"
 description = "HuggingFace community-driven open-source library of datasets"
 category = "main"
 optional = true
 python-versions = ">=3.7.0"
 files = [
-    {file = "datasets-2.10.1-py3-none-any.whl", hash = "sha256:bfde7253b31abfd075f9ad55961b13c135a5a9295cea04ae86c47b9c0e0466fd"},
-    {file = "datasets-2.10.1.tar.gz", hash = "sha256:e2764c90aa3af96450a9747a934b8893b121f79f58d89e123cb1a7046bb8e81e"},
+    {file = "datasets-2.9.0-py3-none-any.whl", hash = "sha256:f1aa5b98959cddb30f5077448204c8ce4235a4f1c8ec2473920660ebd6fc304f"},
+    {file = "datasets-2.9.0.tar.gz", hash = "sha256:c82458d635539b5a5dbed0fba8837006dfc3c213a5bcc00e18a67789f0f0f16f"},
 ]
 
 [package.dependencies]
 aiohttp = "*"
-dill = ">=0.3.0,<0.3.7"
+dill = "<0.3.7"
 fsspec = {version = ">=2021.11.1", extras = ["http"]}
 huggingface-hub = ">=0.2.0,<1.0.0"
 multiprocess = "*"
@@ -954,16 +954,15 @@ xxhash = "*"
 [package.extras]
 apache-beam = ["apache-beam (>=2.26.0,<2.44.0)"]
 audio = ["librosa"]
-benchmarks = ["numpy (==1.18.5)", "protobuf (==3.20.3)", "tensorflow (==2.3.0)", "torch (==1.7.1)", "transformers (==3.0.2)"]
-dev = ["Pillow (>=6.2.1)", "absl-py", "apache-beam (>=2.26.0,<2.44.0)", "black (>=23.1,<24.0)", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "librosa", "lz4", "py7zr", "pytest", "pytest-datadir", "pytest-xdist", "pyyaml (>=5.3.1)", "rarfile (>=4.0)", "ruff (>=0.0.241)", "s3fs", "s3fs (>=2021.11.1)", "soundfile", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "tensorflow-macos", "tiktoken", "torch", "torchaudio (<0.12.0)", "transformers", "zstandard"]
+benchmarks = ["numpy (==1.18.5)", "tensorflow (==2.3.0)", "torch (==1.7.1)", "transformers (==3.0.2)"]
+dev = ["Pillow (>=6.2.1)", "absl-py", "apache-beam (>=2.26.0,<2.44.0)", "black (>=22.0,<23.0)", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "flake8 (>=3.8.3)", "isort (>=5.0.0)", "librosa", "lz4", "py7zr", "pytest", "pytest-datadir", "pytest-xdist", "pyyaml (>=5.3.1)", "rarfile (>=4.0)", "s3fs", "s3fs (>=2021.11.1)", "soundfile", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "tensorflow-macos", "torch", "torchaudio (<0.12.0)", "transformers", "zstandard"]
 docs = ["s3fs"]
-jax = ["jax (>=0.2.8,!=0.3.2,<=0.3.25)", "jaxlib (>=0.1.65,<=0.3.25)"]
-metrics-tests = ["Werkzeug (>=1.0.1)", "bert-score (>=0.3.6)", "jiwer", "langdetect", "mauve-text", "nltk", "requests-file (>=1.5.1)", "rouge-score", "sacrebleu", "sacremoses", "scikit-learn", "scipy", "sentencepiece", "seqeval", "six (>=1.15.0,<1.16.0)", "spacy (>=3.0.0)", "sqlalchemy (<2.0.0)", "texttable (>=1.6.3)", "tldextract", "tldextract (>=3.1.0)", "toml (>=0.10.1)", "typer (<0.5.0)"]
-quality = ["black (>=23.1,<24.0)", "pyyaml (>=5.3.1)", "ruff (>=0.0.241)"]
+metrics-tests = ["Werkzeug (>=1.0.1)", "bert-score (>=0.3.6)", "jiwer", "langdetect", "mauve-text", "nltk", "requests-file (>=1.5.1)", "rouge-score", "sacrebleu", "sacremoses", "scikit-learn", "scipy", "sentencepiece", "seqeval", "six (>=1.15.0,<1.16.0)", "spacy (>=3.0.0)", "sqlalchemy", "texttable (>=1.6.3)", "tldextract", "tldextract (>=3.1.0)", "toml (>=0.10.1)", "typer (<0.5.0)"]
+quality = ["black (>=22.0,<23.0)", "flake8 (>=3.8.3)", "isort (>=5.0.0)", "pyyaml (>=5.3.1)"]
 s3 = ["s3fs"]
 tensorflow = ["tensorflow (>=2.2.0,!=2.6.0,!=2.6.1)", "tensorflow-macos"]
 tensorflow-gpu = ["tensorflow-gpu (>=2.2.0,!=2.6.0,!=2.6.1)"]
-tests = ["Pillow (>=6.2.1)", "absl-py", "apache-beam (>=2.26.0,<2.44.0)", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "librosa", "lz4", "py7zr", "pytest", "pytest-datadir", "pytest-xdist", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "soundfile", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "tensorflow-macos", "tiktoken", "torch", "torchaudio (<0.12.0)", "transformers", "zstandard"]
+tests = ["Pillow (>=6.2.1)", "absl-py", "apache-beam (>=2.26.0,<2.44.0)", "elasticsearch (<8.0.0)", "faiss-cpu (>=1.6.4)", "librosa", "lz4", "py7zr", "pytest", "pytest-datadir", "pytest-xdist", "rarfile (>=4.0)", "s3fs (>=2021.11.1)", "soundfile", "tensorflow (>=2.3,!=2.6.0,!=2.6.1)", "tensorflow-macos", "torch", "torchaudio (<0.12.0)", "transformers", "zstandard"]
 torch = ["torch"]
 vision = ["Pillow (>=6.2.1)"]
 
@@ -1435,14 +1434,14 @@ lxml = ["lxml"]
 
 [[package]]
 name = "huggingface-hub"
-version = "0.12.1"
+version = "0.13.1"
 description = "Client library to download and publish models, datasets and other repos on the huggingface.co hub"
 category = "main"
 optional = true
 python-versions = ">=3.7.0"
 files = [
-    {file = "huggingface_hub-0.12.1-py3-none-any.whl", hash = "sha256:867586cc8543fe1bd43a219fedbea7d71690021ad80f0c46f35c4751069278d7"},
-    {file = "huggingface_hub-0.12.1.tar.gz", hash = "sha256:6f960f6246ef9c3446d0d6275e853485515682c350917fdaf2a59705f8b9ebb3"},
+    {file = "huggingface_hub-0.13.1-py3-none-any.whl", hash = "sha256:b9c2936f51842717ac5b95d014da7b506f344bcf1951b5fe2d79a2fbaed6b1cf"},
+    {file = "huggingface_hub-0.13.1.tar.gz", hash = "sha256:3bfd65465ff805079c39681eaf481882c37d8b80a04d41b3dd448e795bad8b2a"},
 ]
 
 [package.dependencies]
@@ -1454,26 +1453,26 @@ tqdm = ">=4.42.1"
 typing-extensions = ">=3.7.4.3"
 
 [package.extras]
-all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "black (==22.3)", "flake8 (>=3.8.3)", "flake8-bugbear", "isort (>=5.5.4)", "jedi", "mypy (==0.982)", "pytest", "pytest-cov", "pytest-env", "pytest-xdist", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3"]
+all = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "black (>=23.1,<24.0)", "jedi", "mypy (==0.982)", "pytest", "pytest-cov", "pytest-env", "pytest-xdist", "ruff (>=0.0.241)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3"]
 cli = ["InquirerPy (==0.3.4)"]
-dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "black (==22.3)", "flake8 (>=3.8.3)", "flake8-bugbear", "isort (>=5.5.4)", "jedi", "mypy (==0.982)", "pytest", "pytest-cov", "pytest-env", "pytest-xdist", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3"]
+dev = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "black (>=23.1,<24.0)", "jedi", "mypy (==0.982)", "pytest", "pytest-cov", "pytest-env", "pytest-xdist", "ruff (>=0.0.241)", "soundfile", "types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3"]
 fastai = ["fastai (>=2.4)", "fastcore (>=1.3.27)", "toml"]
-quality = ["black (==22.3)", "flake8 (>=3.8.3)", "flake8-bugbear", "isort (>=5.5.4)", "mypy (==0.982)"]
+quality = ["black (>=23.1,<24.0)", "mypy (==0.982)", "ruff (>=0.0.241)"]
 tensorflow = ["graphviz", "pydot", "tensorflow"]
-testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "isort (>=5.5.4)", "jedi", "pytest", "pytest-cov", "pytest-env", "pytest-xdist", "soundfile"]
+testing = ["InquirerPy (==0.3.4)", "Jinja2", "Pillow", "jedi", "pytest", "pytest-cov", "pytest-env", "pytest-xdist", "soundfile"]
 torch = ["torch"]
 typing = ["types-PyYAML", "types-requests", "types-simplejson", "types-toml", "types-tqdm", "types-urllib3"]
 
 [[package]]
 name = "identify"
-version = "2.5.18"
+version = "2.5.19"
 description = "File identification library for Python"
 category = "dev"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "identify-2.5.18-py2.py3-none-any.whl", hash = "sha256:93aac7ecf2f6abf879b8f29a8002d3c6de7086b8c28d88e1ad15045a15ab63f9"},
-    {file = "identify-2.5.18.tar.gz", hash = "sha256:89e144fa560cc4cffb6ef2ab5e9fb18ed9f9b3cb054384bab4b95c12f6c309fe"},
+    {file = "identify-2.5.19-py2.py3-none-any.whl", hash = "sha256:3ee3533e7f6f5023157fbebbd5687bb4b698ce6f305259e0d24b2d7d9efb72bc"},
+    {file = "identify-2.5.19.tar.gz", hash = "sha256:4102ecd051f6884449e7359e55b38ba6cd7aafb6ef27b8e2b38495a5723ea106"},
 ]
 
 [package.extras]
@@ -3141,25 +3140,25 @@ wcwidth = "*"
 
 [[package]]
 name = "protobuf"
-version = "4.22.0"
+version = "4.22.1"
 description = ""
 category = "main"
 optional = true
 python-versions = ">=3.7"
 files = [
-    {file = "protobuf-4.22.0-cp310-abi3-win32.whl", hash = "sha256:b2fea9dc8e3c0f32c38124790ef16cba2ee0628fe2022a52e435e1117bfef9b1"},
-    {file = "protobuf-4.22.0-cp310-abi3-win_amd64.whl", hash = "sha256:a33a273d21852f911b8bda47f39f4383fe7c061eb1814db2c76c9875c89c2491"},
-    {file = "protobuf-4.22.0-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:e894e9ae603e963f0842498c4cd5d39c6a60f0d7e4c103df50ee939564298658"},
-    {file = "protobuf-4.22.0-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:7c535d126e7dcc714105ab20b418c4fedbd28f8b8afc42b7350b1e317bbbcc71"},
-    {file = "protobuf-4.22.0-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:86c3d20428b007537ba6792b475c0853bba7f66b1f60e610d913b77d94b486e4"},
-    {file = "protobuf-4.22.0-cp37-cp37m-win32.whl", hash = "sha256:1669cb7524221a8e2d9008d0842453dbefdd0fcdd64d67672f657244867635fb"},
-    {file = "protobuf-4.22.0-cp37-cp37m-win_amd64.whl", hash = "sha256:ab4d043865dd04e6b09386981fe8f80b39a1e46139fb4a3c206229d6b9f36ff6"},
-    {file = "protobuf-4.22.0-cp38-cp38-win32.whl", hash = "sha256:29288813aacaa302afa2381db1d6e0482165737b0afdf2811df5fa99185c457b"},
-    {file = "protobuf-4.22.0-cp38-cp38-win_amd64.whl", hash = "sha256:e474b63bab0a2ea32a7b26a4d8eec59e33e709321e5e16fb66e766b61b82a95e"},
-    {file = "protobuf-4.22.0-cp39-cp39-win32.whl", hash = "sha256:47d31bdf58222dd296976aa1646c68c6ee80b96d22e0a3c336c9174e253fd35e"},
-    {file = "protobuf-4.22.0-cp39-cp39-win_amd64.whl", hash = "sha256:c27f371f0159feb70e6ea52ed7e768b3f3a4c5676c1900a7e51a24740381650e"},
-    {file = "protobuf-4.22.0-py3-none-any.whl", hash = "sha256:c3325803095fb4c2a48649c321d2fbde59f8fbfcb9bfc7a86df27d112831c571"},
-    {file = "protobuf-4.22.0.tar.gz", hash = "sha256:652d8dfece122a24d98eebfef30e31e455d300efa41999d1182e015984ac5930"},
+    {file = "protobuf-4.22.1-cp310-abi3-win32.whl", hash = "sha256:85aa9acc5a777adc0c21b449dafbc40d9a0b6413ff3a4f77ef9df194be7f975b"},
+    {file = "protobuf-4.22.1-cp310-abi3-win_amd64.whl", hash = "sha256:8bc971d76c03f1dd49f18115b002254f2ddb2d4b143c583bb860b796bb0d399e"},
+    {file = "protobuf-4.22.1-cp37-abi3-macosx_10_9_universal2.whl", hash = "sha256:5917412347e1da08ce2939eb5cd60650dfb1a9ab4606a415b9278a1041fb4d19"},
+    {file = "protobuf-4.22.1-cp37-abi3-manylinux2014_aarch64.whl", hash = "sha256:9e12e2810e7d297dbce3c129ae5e912ffd94240b050d33f9ecf023f35563b14f"},
+    {file = "protobuf-4.22.1-cp37-abi3-manylinux2014_x86_64.whl", hash = "sha256:953fc7904ef46900262a26374b28c2864610b60cdc8b272f864e22143f8373c4"},
+    {file = "protobuf-4.22.1-cp37-cp37m-win32.whl", hash = "sha256:6e100f7bc787cd0a0ae58dbf0ab8bbf1ee7953f862b89148b6cf5436d5e9eaa1"},
+    {file = "protobuf-4.22.1-cp37-cp37m-win_amd64.whl", hash = "sha256:87a6393fa634f294bf24d1cfe9fdd6bb605cbc247af81b9b10c4c0f12dfce4b3"},
+    {file = "protobuf-4.22.1-cp38-cp38-win32.whl", hash = "sha256:e3fb58076bdb550e75db06ace2a8b3879d4c4f7ec9dd86e4254656118f4a78d7"},
+    {file = "protobuf-4.22.1-cp38-cp38-win_amd64.whl", hash = "sha256:651113695bc2e5678b799ee5d906b5d3613f4ccfa61b12252cfceb6404558af0"},
+    {file = "protobuf-4.22.1-cp39-cp39-win32.whl", hash = "sha256:67b7d19da0fda2733702c2299fd1ef6cb4b3d99f09263eacaf1aa151d9d05f02"},
+    {file = "protobuf-4.22.1-cp39-cp39-win_amd64.whl", hash = "sha256:b8700792f88e59ccecfa246fa48f689d6eee6900eddd486cdae908ff706c482b"},
+    {file = "protobuf-4.22.1-py3-none-any.whl", hash = "sha256:3e19dcf4adbf608924d3486ece469dd4f4f2cf7d2649900f0efcd1a84e8fd3ba"},
+    {file = "protobuf-4.22.1.tar.gz", hash = "sha256:dce7a55d501c31ecf688adb2f6c3f763cf11bc0be815d1946a84d74772ab07a7"},
 ]
 
 [[package]]
@@ -4079,33 +4078,33 @@ boto3 = ["aiobotocore[boto3] (>=2.4.2,<2.5.0)"]
 
 [[package]]
 name = "scikit-learn"
-version = "1.2.1"
+version = "1.2.2"
 description = "A set of python modules for machine learning and data mining"
 category = "main"
 optional = true
 python-versions = ">=3.8"
 files = [
-    {file = "scikit-learn-1.2.1.tar.gz", hash = "sha256:fbf8a5c893c9b4b99bcc7ed8fb3e8500957a113f4101860386d06635520f7cfb"},
-    {file = "scikit_learn-1.2.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:bed9f75763bd392c094bf474c7ab75a01d68b15146ea7a20c0f9ff6fb3063dad"},
-    {file = "scikit_learn-1.2.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:c9285275a435d1f8f47bbe3500346ab9ead2499e0e090518404d318ea90d1c1c"},
-    {file = "scikit_learn-1.2.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dc838b5a4057c55ba81b82316ea8bf443af445f96eb21500b0e40618017e0923"},
-    {file = "scikit_learn-1.2.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:d8bcd303dd982494842a3f482f844d539484c6043b4eed896b43ea8e5f609a21"},
-    {file = "scikit_learn-1.2.1-cp310-cp310-win_amd64.whl", hash = "sha256:a9abf17d177df54e529154f26acfd42930e19117d045e8a9a8e893ca82dd94ec"},
-    {file = "scikit_learn-1.2.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:70fa30d146b7e9d0c256e73e271b3e17f23123b7c4adcbde1a385031adf59090"},
-    {file = "scikit_learn-1.2.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5a8111f3c7a314017ebf90d6feab861c11d1ca14f3dbafb39abcc31aa4c54ba6"},
-    {file = "scikit_learn-1.2.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cba0c7c6bf1493f8ce670bab69f9317874826ee838988de377ae355abd4d74cf"},
-    {file = "scikit_learn-1.2.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:479aedd0abedbda6b8b4529145fe4cd8622f69f726a72cef8f75548a93eeb1e1"},
-    {file = "scikit_learn-1.2.1-cp311-cp311-win_amd64.whl", hash = "sha256:5523e21ab2b4d52b2bd41bedd335dbe8f3c1b5f6dd7c9c001b2e17ec9818af8d"},
-    {file = "scikit_learn-1.2.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:dcfab6a19b236194af88771d8e6e778a60c3339248ab0018696ebf2b7c8bed4b"},
-    {file = "scikit_learn-1.2.1-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:559f66e12f93b34c8c85c0a5728c3b8af98f04eb12f2c9ee18ea3c82c3d2fad1"},
-    {file = "scikit_learn-1.2.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:dbb7831b2308c67bb6dd83c5ea3cdaf8e8cafd2de4000b93d78bb689126bd2cf"},
-    {file = "scikit_learn-1.2.1-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5b2c5d9930ced2b7821ad936b9940706ccb5471d89b8a516bb641cec87257d1c"},
-    {file = "scikit_learn-1.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:54731e2c2fbff40da6d76cbb9022ace5f44a4020a10bd5cd92107e86882bad15"},
-    {file = "scikit_learn-1.2.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d00e46a2a7fce6e118ed0f4c6263785bf6c297a94ffd0cd7b32455043c508cc8"},
-    {file = "scikit_learn-1.2.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:da0e2d50a8435ea8dc5cd21f1fc1a45d329bae03dcca92087ebed859d22d184e"},
-    {file = "scikit_learn-1.2.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:61bb9c654b5d2e6cdd4b1c7e6048fc66270c1682bda1b0f7d2726fdae09010f4"},
-    {file = "scikit_learn-1.2.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:e0ee4d4d32c94e082344308528f7b3c9294b60ab19c84eb37a2d9c88bdffd9d1"},
-    {file = "scikit_learn-1.2.1-cp39-cp39-win_amd64.whl", hash = "sha256:c722f3446ad8c4f1a93b2399fe1a188635b94709a3f25e6f4d61efbe75fe8eaa"},
+    {file = "scikit-learn-1.2.2.tar.gz", hash = "sha256:8429aea30ec24e7a8c7ed8a3fa6213adf3814a6efbea09e16e0a0c71e1a1a3d7"},
+    {file = "scikit_learn-1.2.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:99cc01184e347de485bf253d19fcb3b1a3fb0ee4cea5ee3c43ec0cc429b6d29f"},
+    {file = "scikit_learn-1.2.2-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:e6e574db9914afcb4e11ade84fab084536a895ca60aadea3041e85b8ac963edb"},
+    {file = "scikit_learn-1.2.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:6fe83b676f407f00afa388dd1fdd49e5c6612e551ed84f3b1b182858f09e987d"},
+    {file = "scikit_learn-1.2.2-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2e2642baa0ad1e8f8188917423dd73994bf25429f8893ddbe115be3ca3183584"},
+    {file = "scikit_learn-1.2.2-cp310-cp310-win_amd64.whl", hash = "sha256:ad66c3848c0a1ec13464b2a95d0a484fd5b02ce74268eaa7e0c697b904f31d6c"},
+    {file = "scikit_learn-1.2.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:dfeaf8be72117eb61a164ea6fc8afb6dfe08c6f90365bde2dc16456e4bc8e45f"},
+    {file = "scikit_learn-1.2.2-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:fe0aa1a7029ed3e1dcbf4a5bc675aa3b1bc468d9012ecf6c6f081251ca47f590"},
+    {file = "scikit_learn-1.2.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:065e9673e24e0dc5113e2dd2b4ca30c9d8aa2fa90f4c0597241c93b63130d233"},
+    {file = "scikit_learn-1.2.2-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bf036ea7ef66115e0d49655f16febfa547886deba20149555a41d28f56fd6d3c"},
+    {file = "scikit_learn-1.2.2-cp311-cp311-win_amd64.whl", hash = "sha256:8b0670d4224a3c2d596fd572fb4fa673b2a0ccfb07152688ebd2ea0b8c61025c"},
+    {file = "scikit_learn-1.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:9c710ff9f9936ba8a3b74a455ccf0dcf59b230caa1e9ba0223773c490cab1e51"},
+    {file = "scikit_learn-1.2.2-cp38-cp38-macosx_12_0_arm64.whl", hash = "sha256:2dd3ffd3950e3d6c0c0ef9033a9b9b32d910c61bd06cb8206303fb4514b88a49"},
+    {file = "scikit_learn-1.2.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:44b47a305190c28dd8dd73fc9445f802b6ea716669cfc22ab1eb97b335d238b1"},
+    {file = "scikit_learn-1.2.2-cp38-cp38-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:953236889928d104c2ef14027539f5f2609a47ebf716b8cbe4437e85dce42744"},
+    {file = "scikit_learn-1.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:7f69313884e8eb311460cc2f28676d5e400bd929841a2c8eb8742ae78ebf7c20"},
+    {file = "scikit_learn-1.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:8156db41e1c39c69aa2d8599ab7577af53e9e5e7a57b0504e116cc73c39138dd"},
+    {file = "scikit_learn-1.2.2-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:fe175ee1dab589d2e1033657c5b6bec92a8a3b69103e3dd361b58014729975c3"},
+    {file = "scikit_learn-1.2.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7d5312d9674bed14f73773d2acf15a3272639b981e60b72c9b190a0cffed5bad"},
+    {file = "scikit_learn-1.2.2-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ea061bf0283bf9a9f36ea3c5d3231ba2176221bbd430abd2603b1c3b2ed85c89"},
+    {file = "scikit_learn-1.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:6477eed40dbce190f9f9e9d0d37e020815825b300121307942ec2110302b66a3"},
 ]
 
 [package.dependencies]
@@ -4225,14 +4224,14 @@ files = [
 
 [[package]]
 name = "setuptools"
-version = "67.5.1"
+version = "67.6.0"
 description = "Easily download, build, install, upgrade, and uninstall Python packages"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 files = [
-    {file = "setuptools-67.5.1-py3-none-any.whl", hash = "sha256:1c39d42bda4cb89f7fdcad52b6762e3c309ec8f8715b27c684176b7d71283242"},
-    {file = "setuptools-67.5.1.tar.gz", hash = "sha256:15136a251127da2d2e77ac7a1bc231eb504654f7e3346d93613a13f2e2787535"},
+    {file = "setuptools-67.6.0-py3-none-any.whl", hash = "sha256:b78aaa36f6b90a074c1fa651168723acbf45d14cb1196b6f02c0fd07f17623b2"},
+    {file = "setuptools-67.6.0.tar.gz", hash = "sha256:2ee892cd5f29f3373097f5a814697e397cf3ce313616df0af11231e2ad118077"},
 ]
 
 [package.extras]
@@ -5472,4 +5471,4 @@ ocr = ["python-doctr", "torch", "torchvision", "opencv-python"]
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.8.2"
-content-hash = "ca58e217594603a4cfde2cdb13c2655fab205a5d5decd6a9ff6e994c87ece7a0"
+content-hash = "96ca2c5e236dc587977b87cfb166de21478f8a5067a254a550adc5e95d25a1b1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,8 @@ torchvision = { version = "^0.14.1", optional = true }
 opencv-python = { version = "^4.6.0.66", optional = true }
 # baselines
 transformers = { version = "~4.26.1", optional = true }
-datasets = { version = "^2.8.0", extras = ["s3"], optional = true }
+# pin datasets version to avoid https://github.com/apache/arrow/issues/34455
+datasets = { version = "^2.8.0,<2.10.0", extras = ["s3"], optional = true }
 torchmetrics = { version = "^0.11.0", optional = true }
 sentencepiece = { version = "^0.1.97", optional = true }
 tensorboard = { version = "^2.11.2", optional = true }


### PR DESCRIPTION
The added logic is at the top of `prepare_hf_dataset` where dataset is preprocessed by chunks of 10000 documents. Storing to arrow format must be turned on so that it's possible to then concatenate the stored datasets. Although it was not failing for RoBERTa, only for LayoutLMv3, I made the changes there as well to make the files as in sync as possible. Also as a side effect, this change should significantly decrease RAM usage (at the cost of increasing disk usage but the preprocessed arrow dataset can be deleted after training).

I also created a function `prepare_hf_dataset` to remove some duplicated code (loading of `val` and training datasets) and simplified the script arguments for loading/storing preprocessed/arrow datasets.