### PR TITLE
Support splits with no annotations

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Table of Contents:
 First you need to obtain a secret token by following the instructions at https://docile.rossum.ai/. Then download and unzip the dataset by running:
 ```bash
 ./download_dataset.sh TOKEN annotated-trainval data/docile --unzip
+./download_dataset.sh TOKEN test data/docile --unzip
 ./download_dataset.sh TOKEN synthetic data/docile --unzip
 ./download_dataset.sh TOKEN unlabeled data/docile --unzip
 ```

--- a/baselines/NER/docile_inference_NER_multilabel.py
+++ b/baselines/NER/docile_inference_NER_multilabel.py
@@ -407,8 +407,6 @@ if __name__ == "__main__":
 
     for document in tqdm(dataset):
         doc_id = document.docid
-        gt_kile_fields = document.annotation.fields
-        gt_li_fields = document.annotation.li_fields
         pred_kile_fields = []
         pred_kile_fields_final = []
         pred_li_fields = []
@@ -417,18 +415,8 @@ if __name__ == "__main__":
         intermediate_fields = []
         li_id = -1
         for page in range(document.page_count):
-            gt_kile_fields_page = [field for field in gt_kile_fields if field.page == page]
-            gt_li_fields_page = [field for field in gt_li_fields if field.page == page]
             img = document.page_image(page)
             W, H = img.size
-            gt_kile_fields_page = [
-                dataclasses.replace(field, bbox=field.bbox.to_absolute_coords(W, H))
-                for field in gt_kile_fields_page
-            ]
-            gt_li_fields_page = [
-                dataclasses.replace(field, bbox=field.bbox.to_absolute_coords(W, H))
-                for field in gt_li_fields_page
-            ]
             ocr = document.ocr.get_all_words(page, snapped=True)
             ocr = [
                 dataclasses.replace(ocr_field, bbox=ocr_field.bbox.to_absolute_coords(W, H))

--- a/baselines/NER/docile_inference_NER_multilabel_layoutLMv3.py
+++ b/baselines/NER/docile_inference_NER_multilabel_layoutLMv3.py
@@ -351,8 +351,6 @@ if __name__ == "__main__":
 
     for document in tqdm(dataset):
         doc_id = document.docid
-        gt_kile_fields = document.annotation.fields
-        gt_li_fields = document.annotation.li_fields
         pred_kile_fields = []
         pred_kile_fields_final = []
         pred_li_fields = []
@@ -361,22 +359,11 @@ if __name__ == "__main__":
         intermediate_fields = []
         li_id = -1
         for page in range(document.page_count):
-            gt_kile_fields_page = [field for field in gt_kile_fields if field.page == page]
-            gt_li_fields_page = [field for field in gt_li_fields if field.page == page]
             img = document.page_image(page)
             W, H = img.size
             img_preprocessed = np.array(
                 img.resize((224, 224), Image.BICUBIC), dtype=np.uint8
             ).transpose([2, 0, 1])
-
-            gt_kile_fields_page = [
-                dataclasses.replace(field, bbox=field.bbox.to_absolute_coords(W, H))
-                for field in gt_kile_fields_page
-            ]
-            gt_li_fields_page = [
-                dataclasses.replace(field, bbox=field.bbox.to_absolute_coords(W, H))
-                for field in gt_li_fields_page
-            ]
             ocr = document.ocr.get_all_words(page, snapped=True)
             ocr = [
                 dataclasses.replace(ocr_field, bbox=ocr_field.bbox.to_absolute_coords(W, H))

--- a/docile/tools/dataset_browser.py
+++ b/docile/tools/dataset_browser.py
@@ -283,7 +283,10 @@ class DatasetBrowser:
 
         display_boxes = []
 
-        table_grid = annotation.get_table_grid(self.page_i)
+        try:
+            table_grid = annotation.get_table_grid(self.page_i)
+        except KeyError:
+            table_grid = None
         if table_grid is not None:
             display_boxes.append(
                 DisplayBox(table_grid.bbox, "[Table area]", DisplayType.TABLE_AREA)
@@ -336,9 +339,13 @@ class DatasetBrowser:
                     ]
                 )
         else:
-            fields_types.extend(
-                [(f, DisplayType.ANNOTATION) for f in annotation.page_fields(self.page_i)]
-            )
+            try:
+                fields_types.extend(
+                    [(f, DisplayType.ANNOTATION) for f in annotation.page_fields(self.page_i)]
+                )
+            except KeyError:
+                # annotations not available, this can happen for test set or unlabeled set
+                pass
             if self.kile_predictions is not None:
                 fields_types.extend(
                     [
@@ -383,9 +390,13 @@ class DatasetBrowser:
                     ]
                 )
         else:
-            fields_types.extend(
-                [(f, DisplayType.ANNOTATION) for f in annotation.page_li_fields(self.page_i)]
-            )
+            try:
+                fields_types.extend(
+                    [(f, DisplayType.ANNOTATION) for f in annotation.page_li_fields(self.page_i)]
+                )
+            except KeyError:
+                # annotations not available, this can happen for test set or unlabeled set
+                pass
             if self.lir_predictions is not None:
                 fields_types.extend(
                     [


### PR DESCRIPTION
The inference scripts still fail at the end since they try to run the evaluation. This happens only after the predictions are computed and stored so it doesn't cause any (practical) problems.